### PR TITLE
feat(api): implement POST /api/crash-reports endpoint

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,5 +1,6 @@
 import configureOpenAPI from '@/lib/configure-open-api';
 import createApp from '@/lib/create-app';
+import crashReports from '@/routes/crash-reports/crash-reports.index';
 import health from '@/routes/health.route';
 import index from '@/routes/index.route';
 
@@ -7,7 +8,7 @@ const app = createApp();
 
 configureOpenAPI(app);
 
-const routes = [index, health] as const;
+const routes = [index, health, crashReports] as const;
 
 for (const route of routes) {
 	app.route('/', route);

--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -4,34 +4,69 @@
  * For self-hosting, configure this file with your database connection.
  * By default, uses SQLite in the data/ directory.
  *
- * Example configurations:
- *
- * SQLite (default):
- *   import Database from 'better-sqlite3';
- *   import { drizzle } from 'drizzle-orm/better-sqlite3';
- *   const sqlite = new Database('./data/ctd.db');
- *   export const db = drizzle(sqlite, { schema });
- *
- * PostgreSQL:
- *   import { drizzle } from 'drizzle-orm/node-postgres';
- *   import { Pool } from 'pg';
- *   const pool = new Pool({ connectionString: process.env.DATABASE_URL });
- *   export const db = drizzle(pool, { schema });
+ * Set DATABASE_URL=:memory: for in-memory database (used in tests).
  */
 
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import * as schema from './schema.js';
 
-// Ensure data directory exists
-import { mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
+const dbPath = process.env.DATABASE_URL || './data/ctd.db';
+const isMemory = dbPath === ':memory:';
 
-const dbPath = './data/ctd.db';
-mkdirSync(dirname(dbPath), { recursive: true });
+if (!isMemory) {
+	mkdirSync(dirname(dbPath), { recursive: true });
+}
 
 const sqlite = new Database(dbPath);
-sqlite.pragma('journal_mode = WAL');
+
+if (!isMemory) {
+	sqlite.pragma('journal_mode = WAL');
+}
+
+// Create tables for in-memory database
+if (isMemory) {
+	sqlite.exec(`
+		CREATE TABLE IF NOT EXISTS crash_report (
+			id TEXT PRIMARY KEY,
+			game_id TEXT NOT NULL,
+			user_id TEXT,
+			crash_hash TEXT NOT NULL,
+			stack_trace TEXT NOT NULL,
+			exception_code TEXT,
+			exception_address TEXT,
+			faulting_module TEXT,
+			game_version TEXT NOT NULL,
+			script_extender_version TEXT,
+			os_version TEXT,
+			load_order_json TEXT NOT NULL,
+			plugin_count INTEGER NOT NULL,
+			crashed_at INTEGER NOT NULL,
+			submitted_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+			is_public INTEGER NOT NULL DEFAULT 0,
+			share_token TEXT UNIQUE,
+			notes TEXT,
+			created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+		);
+
+		CREATE TABLE IF NOT EXISTS crash_pattern (
+			id TEXT PRIMARY KEY,
+			game_id TEXT NOT NULL,
+			crash_hash TEXT NOT NULL UNIQUE,
+			pattern_name TEXT,
+			occurrence_count INTEGER NOT NULL DEFAULT 1,
+			first_seen_at INTEGER NOT NULL,
+			last_seen_at INTEGER NOT NULL,
+			suspected_mods_json TEXT,
+			known_fix TEXT,
+			is_resolved INTEGER NOT NULL DEFAULT 0,
+			created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+			updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+		);
+	`);
+}
 
 export const db = drizzle(sqlite, { schema });
 

--- a/api/src/db/schema.zod.ts
+++ b/api/src/db/schema.zod.ts
@@ -1,0 +1,71 @@
+import { z } from '@hono/zod-openapi';
+
+export const loadOrderItemSchema = z.object({
+	name: z.string(),
+	enabled: z.boolean().optional(),
+	index: z.number().int().optional(),
+});
+
+export const loadOrderSchema = z.array(loadOrderItemSchema);
+
+export const createCrashReportSchema = z.object({
+	gameId: z.string().min(1),
+	stackTrace: z.string().min(1).max(100000),
+	crashHash: z.string().min(1).max(64).optional(),
+	exceptionCode: z.string().max(50).optional(),
+	exceptionAddress: z.string().max(50).optional(),
+	faultingModule: z.string().max(255).optional(),
+	gameVersion: z.string().min(1).max(50),
+	scriptExtenderVersion: z.string().max(50).optional(),
+	osVersion: z.string().max(100).optional(),
+	loadOrderJson: z.string().refine(
+		(val) => {
+			try {
+				const parsed = JSON.parse(val);
+				return Array.isArray(parsed);
+			} catch {
+				return false;
+			}
+		},
+		{ message: 'loadOrderJson must be a valid JSON array' },
+	),
+	pluginCount: z.number().int().min(0).max(10000),
+	crashedAt: z.number().int().positive(),
+	notes: z.string().max(5000).optional(),
+});
+
+export const crashReportResponseSchema = z.object({
+	id: z.string(),
+	shareToken: z.string(),
+});
+
+export const selectCrashReportSchema = z.object({
+	id: z.string(),
+	gameId: z.string(),
+	crashHash: z.string(),
+	stackTrace: z.string(),
+	exceptionCode: z.string().nullable(),
+	exceptionAddress: z.string().nullable(),
+	faultingModule: z.string().nullable(),
+	gameVersion: z.string(),
+	scriptExtenderVersion: z.string().nullable(),
+	osVersion: z.string().nullable(),
+	loadOrder: loadOrderSchema,
+	pluginCount: z.number(),
+	crashedAt: z.number(),
+	submittedAt: z.number(),
+	isPublic: z.boolean(),
+	notes: z.string().nullable(),
+	pattern: z
+		.object({
+			id: z.string(),
+			patternName: z.string().nullable(),
+			occurrenceCount: z.number(),
+			knownFix: z.string().nullable(),
+		})
+		.nullable(),
+});
+
+export type CreateCrashReport = z.infer<typeof createCrashReportSchema>;
+export type CrashReportResponse = z.infer<typeof crashReportResponseSchema>;
+export type SelectCrashReport = z.infer<typeof selectCrashReportSchema>;

--- a/api/src/routes/crash-reports/crash-reports.handlers.ts
+++ b/api/src/routes/crash-reports/crash-reports.handlers.ts
@@ -1,0 +1,103 @@
+import { eq } from 'drizzle-orm';
+import * as HttpStatusCodes from 'stoker/http-status-codes';
+import { uuidv7 } from 'uuidv7';
+
+import { crashPattern, crashReport, db } from '@/db/index';
+import type { AppRouteHandler } from '@/lib/types';
+
+import type { SubmitCrashReportRoute } from './crash-reports.routes';
+
+function generateShareToken(): string {
+	const chars =
+		'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	let token = '';
+	for (let i = 0; i < 16; i++) {
+		token += chars.charAt(Math.floor(Math.random() * chars.length));
+	}
+	return token;
+}
+
+function computeCrashHash(stackTrace: string): string {
+	// Simple hash for now - will be replaced with proper implementation in Issue #5
+	const normalized = stackTrace
+		.split('\n')
+		.slice(0, 10)
+		.map((line) => line.trim().toLowerCase())
+		.join('|');
+
+	// Simple string hash
+	let hash = 0;
+	for (let i = 0; i < normalized.length; i++) {
+		const char = normalized.charCodeAt(i);
+		hash = (hash << 5) - hash + char;
+		hash = hash & hash;
+	}
+	return Math.abs(hash).toString(16).padStart(16, '0').slice(0, 16);
+}
+
+export const submitCrashReport: AppRouteHandler<
+	SubmitCrashReportRoute
+> = async (c) => {
+	const body = c.req.valid('json');
+
+	const id = uuidv7();
+	const shareToken = generateShareToken();
+	const crashHash = body.crashHash || computeCrashHash(body.stackTrace);
+	const now = new Date();
+
+	// Insert crash report
+	await db.insert(crashReport).values({
+		id,
+		gameId: body.gameId,
+		crashHash,
+		stackTrace: body.stackTrace,
+		exceptionCode: body.exceptionCode,
+		exceptionAddress: body.exceptionAddress,
+		faultingModule: body.faultingModule,
+		gameVersion: body.gameVersion,
+		scriptExtenderVersion: body.scriptExtenderVersion,
+		osVersion: body.osVersion,
+		loadOrderJson: body.loadOrderJson,
+		pluginCount: body.pluginCount,
+		crashedAt: new Date(body.crashedAt),
+		submittedAt: now,
+		shareToken,
+		notes: body.notes,
+		createdAt: now,
+	});
+
+	// Update or create crash pattern
+	const existingPattern = await db.query.crashPattern.findFirst({
+		where: (pattern, { eq }) => eq(pattern.crashHash, crashHash),
+	});
+
+	if (existingPattern) {
+		await db
+			.update(crashPattern)
+			.set({
+				occurrenceCount: existingPattern.occurrenceCount + 1,
+				lastSeenAt: now,
+				updatedAt: now,
+			})
+			.where(eq(crashPattern.id, existingPattern.id));
+	} else {
+		await db.insert(crashPattern).values({
+			id: uuidv7(),
+			gameId: body.gameId,
+			crashHash,
+			occurrenceCount: 1,
+			firstSeenAt: now,
+			lastSeenAt: now,
+			createdAt: now,
+			updatedAt: now,
+		});
+	}
+
+	return c.json(
+		{
+			id,
+			shareToken,
+		},
+		HttpStatusCodes.CREATED,
+	);
+};

--- a/api/src/routes/crash-reports/crash-reports.index.ts
+++ b/api/src/routes/crash-reports/crash-reports.index.ts
@@ -1,0 +1,11 @@
+import { createRouter } from '@/lib/create-app';
+
+import * as handlers from './crash-reports.handlers';
+import * as routes from './crash-reports.routes';
+
+const router = createRouter().openapi(
+	routes.submitCrashReport,
+	handlers.submitCrashReport,
+);
+
+export default router;

--- a/api/src/routes/crash-reports/crash-reports.routes.ts
+++ b/api/src/routes/crash-reports/crash-reports.routes.ts
@@ -1,0 +1,43 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import * as HttpStatusCodes from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import {
+	crashReportResponseSchema,
+	createCrashReportSchema,
+} from '@/db/schema.zod';
+
+const errorSchema = z.object({
+	error: z.object({
+		code: z.string(),
+		message: z.string(),
+	}),
+});
+
+export const submitCrashReport = createRoute({
+	method: 'post',
+	path: '/api/crash-reports',
+	tags: ['Crash Reports'],
+	summary: 'Submit a new crash report',
+	request: {
+		body: {
+			content: {
+				'application/json': {
+					schema: createCrashReportSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		[HttpStatusCodes.CREATED]: jsonContent(
+			crashReportResponseSchema,
+			'Crash report created',
+		),
+		[HttpStatusCodes.UNPROCESSABLE_ENTITY]: jsonContent(
+			errorSchema,
+			'Validation error',
+		),
+	},
+});
+
+export type SubmitCrashReportRoute = typeof submitCrashReport;

--- a/api/test/routes/crash-reports.test.ts
+++ b/api/test/routes/crash-reports.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { app } from '../../src/app';
+
+describe('POST /api/crash-reports', () => {
+	it('should create a crash report', async () => {
+		const res = await app.request('/api/crash-reports', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				gameId: 'skyrim-se',
+				stackTrace: 'SkyrimSE.exe+0x12345\nENBSeries.dll+0x67890',
+				gameVersion: '1.6.1130',
+				loadOrderJson:
+					'[{"name":"Unofficial Skyrim Special Edition Patch.esp","enabled":true}]',
+				pluginCount: 1,
+				crashedAt: Date.now(),
+			}),
+		});
+
+		expect(res.status).toBe(201);
+		const json = await res.json();
+		expect(json.id).toBeDefined();
+		expect(json.shareToken).toBeDefined();
+		expect(json.shareToken).toHaveLength(16);
+	});
+
+	it('should accept optional crashHash', async () => {
+		const res = await app.request('/api/crash-reports', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				gameId: 'skyrim-se',
+				stackTrace: 'crash',
+				crashHash: 'abc123def456',
+				gameVersion: '1.6.1130',
+				loadOrderJson: '[]',
+				pluginCount: 0,
+				crashedAt: Date.now(),
+			}),
+		});
+
+		expect(res.status).toBe(201);
+	});
+
+	it('should reject invalid loadOrderJson', async () => {
+		const res = await app.request('/api/crash-reports', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				gameId: 'skyrim-se',
+				stackTrace: 'crash',
+				gameVersion: '1.6.1130',
+				loadOrderJson: 'not json',
+				pluginCount: 0,
+				crashedAt: Date.now(),
+			}),
+		});
+
+		expect(res.status).toBe(422);
+	});
+
+	it('should reject missing required fields', async () => {
+		const res = await app.request('/api/crash-reports', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				gameId: 'skyrim-se',
+			}),
+		});
+
+		expect(res.status).toBe(422);
+	});
+
+	it('should accept optional fields', async () => {
+		const res = await app.request('/api/crash-reports', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				gameId: 'skyrim-se',
+				stackTrace: 'SkyrimSE.exe+0x12345',
+				gameVersion: '1.6.1130',
+				loadOrderJson: '[]',
+				pluginCount: 0,
+				crashedAt: Date.now(),
+				exceptionCode: 'EXCEPTION_ACCESS_VIOLATION',
+				exceptionAddress: '0x7FF712345678',
+				faultingModule: 'SkyrimSE.exe',
+				scriptExtenderVersion: '2.2.3',
+				osVersion: 'Windows 10 22H2',
+				notes: 'Crashed after fast travel',
+			}),
+		});
+
+		expect(res.status).toBe(201);
+	});
+});

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -11,5 +11,8 @@ export default defineConfig({
 		globals: true,
 		environment: 'node',
 		include: ['test/**/*.test.ts'],
+		env: {
+			DATABASE_URL: ':memory:',
+		},
 	},
 });


### PR DESCRIPTION
## Summary
- Add crash report submission endpoint with Zod validation
- Generate UUIDv7 for report IDs and random 16-char share tokens
- Create/update crash patterns on submission
- Configure in-memory SQLite for tests

## Test plan
- [x] POST /api/crash-reports returns 201 with id and shareToken
- [x] Validation errors return 422
- [x] Optional fields accepted
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)