### PR TITLE
feat(api): implement crash hash algorithm for deduplication

### DIFF
--- a/api/src/lib/crash-hash.ts
+++ b/api/src/lib/crash-hash.ts
@@ -1,0 +1,88 @@
+import { createHash } from 'node:crypto';
+
+export interface StackFrame {
+	module: string;
+	offset: string;
+	isSystemFrame: boolean;
+}
+
+const SYSTEM_MODULES = new Set([
+	'ntdll.dll',
+	'kernel32.dll',
+	'kernelbase.dll',
+	'win32u.dll',
+	'user32.dll',
+	'gdi32.dll',
+	'msvcrt.dll',
+	'ucrtbase.dll',
+	'vcruntime140.dll',
+	'msvcp140.dll',
+]);
+
+export function isSystemModule(module: string): boolean {
+	return SYSTEM_MODULES.has(module.toLowerCase());
+}
+
+// Crash Logger format: [0] 0x7FF712345678 SkyrimSE.exe+0x12345
+const CRASH_LOGGER_REGEX = /\[\d+\]\s+0x[0-9A-Fa-f]+\s+([^\s+]+)\+(\S+)/;
+
+// .NET Script Framework format: SkyrimSE.exe+12345
+const SCRIPT_FRAMEWORK_REGEX = /^([^\s+]+)\+(\S+)$/;
+
+export function parseStackTrace(stackTrace: string): StackFrame[] {
+	if (!stackTrace.trim()) {
+		return [];
+	}
+
+	const frames: StackFrame[] = [];
+	const lines = stackTrace.split('\n');
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+
+		let match = trimmed.match(CRASH_LOGGER_REGEX);
+		if (match) {
+			const module = match[1];
+			frames.push({
+				module,
+				offset: match[2],
+				isSystemFrame: isSystemModule(module),
+			});
+			continue;
+		}
+
+		match = trimmed.match(SCRIPT_FRAMEWORK_REGEX);
+		if (match) {
+			const module = match[1];
+			frames.push({
+				module,
+				offset: match[2],
+				isSystemFrame: isSystemModule(module),
+			});
+		}
+	}
+
+	return frames;
+}
+
+function sha256(input: string): string {
+	return createHash('sha256').update(input).digest('hex');
+}
+
+export function computeCrashHash(stackTrace: string): string {
+	const frames = parseStackTrace(stackTrace);
+
+	const normalized = frames
+		.filter((f) => !f.isSystemFrame)
+		.slice(0, 10)
+		.map((f) => `${f.module.toLowerCase()}+${f.offset}`)
+		.join('|');
+
+	if (!normalized) {
+		// Fallback: hash entire trace if no game frames
+		return sha256(stackTrace).slice(0, 16);
+	}
+
+	return sha256(normalized).slice(0, 16);
+}

--- a/api/src/lib/index.ts
+++ b/api/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './crash-hash.js';
+export * from './gzip.js';

--- a/api/src/routes/crashes.ts
+++ b/api/src/routes/crashes.ts
@@ -10,6 +10,7 @@ import {
 	createCrashReportSchema,
 	db,
 } from '@/db/index';
+import { computeCrashHash } from '@/lib/crash-hash';
 
 const crashes = new Hono();
 
@@ -25,23 +26,6 @@ function generateShareToken(): string {
 		Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
 	];
 	return sqids.encode(randomValues);
-}
-
-function computeCrashHash(stackTrace: string): string {
-	// Simple hash - will be replaced with proper implementation
-	const normalized = stackTrace
-		.split('\n')
-		.slice(0, 10)
-		.map((line) => line.trim().toLowerCase())
-		.join('|');
-
-	let hash = 0;
-	for (let i = 0; i < normalized.length; i++) {
-		const char = normalized.charCodeAt(i);
-		hash = (hash << 5) - hash + char;
-		hash = hash & hash;
-	}
-	return Math.abs(hash).toString(16).padStart(16, '0').slice(0, 16);
 }
 
 // POST /crashes - Submit a crash report

--- a/api/test/lib/crash-hash.test.ts
+++ b/api/test/lib/crash-hash.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	computeCrashHash,
+	isSystemModule,
+	parseStackTrace,
+} from '@/lib/crash-hash';
+
+describe('isSystemModule', () => {
+	it('should identify system modules', () => {
+		expect(isSystemModule('ntdll.dll')).toBe(true);
+		expect(isSystemModule('kernel32.dll')).toBe(true);
+		expect(isSystemModule('KERNELBASE.DLL')).toBe(true);
+	});
+
+	it('should not flag game modules', () => {
+		expect(isSystemModule('SkyrimSE.exe')).toBe(false);
+		expect(isSystemModule('ENBSeries.dll')).toBe(false);
+		expect(isSystemModule('SKSE64_1_6_1130.dll')).toBe(false);
+	});
+});
+
+describe('parseStackTrace', () => {
+	it('should parse Crash Logger format', () => {
+		const trace = '[0] 0x7FF712345678 SkyrimSE.exe+0x12345';
+		const frames = parseStackTrace(trace);
+
+		expect(frames).toHaveLength(1);
+		expect(frames[0].module).toBe('SkyrimSE.exe');
+		expect(frames[0].offset).toBe('0x12345');
+		expect(frames[0].isSystemFrame).toBe(false);
+	});
+
+	it('should parse .NET Script Framework format', () => {
+		const trace = 'SkyrimSE.exe+12345';
+		const frames = parseStackTrace(trace);
+
+		expect(frames).toHaveLength(1);
+		expect(frames[0].module).toBe('SkyrimSE.exe');
+		expect(frames[0].offset).toBe('12345');
+	});
+
+	it('should parse multiple frames', () => {
+		const trace = `[0] 0x7FF712345678 SkyrimSE.exe+0x12345
+[1] 0x7FF712345679 ENBSeries.dll+0x67890
+[2] 0x7FF712345680 ntdll.dll+0xAAAAA`;
+		const frames = parseStackTrace(trace);
+
+		expect(frames).toHaveLength(3);
+		expect(frames[0].module).toBe('SkyrimSE.exe');
+		expect(frames[1].module).toBe('ENBSeries.dll');
+		expect(frames[2].module).toBe('ntdll.dll');
+		expect(frames[2].isSystemFrame).toBe(true);
+	});
+
+	it('should handle empty stack trace', () => {
+		expect(parseStackTrace('')).toEqual([]);
+		expect(parseStackTrace('   ')).toEqual([]);
+	});
+
+	it('should skip unparseable lines', () => {
+		const trace = `some random text
+SkyrimSE.exe+12345
+more garbage`;
+		const frames = parseStackTrace(trace);
+
+		expect(frames).toHaveLength(1);
+		expect(frames[0].module).toBe('SkyrimSE.exe');
+	});
+});
+
+describe('computeCrashHash', () => {
+	it('should produce same hash for equivalent crashes', () => {
+		const trace1 =
+			'[0] 0x7FF712345678 SkyrimSE.exe+0x12345\n[1] 0x7FF712345679 ENBSeries.dll+0x67890';
+		const trace2 =
+			'[0] 0x7FF799999999 SkyrimSE.exe+0x12345\n[1] 0x7FF788888888 ENBSeries.dll+0x67890';
+
+		expect(computeCrashHash(trace1)).toBe(computeCrashHash(trace2));
+	});
+
+	it('should produce different hash for different crashes', () => {
+		const trace1 = 'SkyrimSE.exe+0x12345';
+		const trace2 = 'SkyrimSE.exe+0x99999';
+
+		expect(computeCrashHash(trace1)).not.toBe(computeCrashHash(trace2));
+	});
+
+	it('should exclude system frames', () => {
+		const trace =
+			'SkyrimSE.exe+0x12345\nntdll.dll+0x99999\nkernel32.dll+0x88888';
+		const frames = parseStackTrace(trace);
+		const nonSystem = frames.filter((f) => !f.isSystemFrame);
+
+		expect(nonSystem).toHaveLength(1);
+		expect(nonSystem[0].module).toBe('SkyrimSE.exe');
+	});
+
+	it('should handle empty stack trace', () => {
+		const hash = computeCrashHash('');
+		expect(hash).toHaveLength(16);
+	});
+
+	it('should be case-insensitive for modules', () => {
+		const trace1 = 'SkyrimSE.exe+0x12345';
+		const trace2 = 'skyrimse.exe+0x12345';
+
+		expect(computeCrashHash(trace1)).toBe(computeCrashHash(trace2));
+	});
+
+	it('should produce 16-character hex hash', () => {
+		const hash = computeCrashHash('SkyrimSE.exe+0x12345');
+
+		expect(hash).toHaveLength(16);
+		expect(hash).toMatch(/^[0-9a-f]+$/);
+	});
+
+	it('should only use top 10 frames', () => {
+		const frames = Array.from(
+			{ length: 15 },
+			(_, i) => `Module${i}.dll+0x${i}`,
+		).join('\n');
+
+		const hash = computeCrashHash(frames);
+		expect(hash).toHaveLength(16);
+	});
+
+	it('should fallback to full trace hash when only system frames', () => {
+		const trace = 'ntdll.dll+0x12345\nkernel32.dll+0x67890';
+		const hash = computeCrashHash(trace);
+
+		expect(hash).toHaveLength(16);
+	});
+});


### PR DESCRIPTION
## Summary
- Implements proper crash hash algorithm for pattern matching
- Parses Crash Logger and .NET Script Framework stack trace formats
- Filters Windows system frames (ntdll, kernel32, etc.)
- Normalizes module names (case-insensitive)
- Takes top 10 non-system frames → SHA-256 → 16-char hash

## Why this matters
Same crash at different memory addresses now produces identical hash. This enables accurate duplicate detection across users for the ML training data.

## Test plan
- [x] 15 unit tests for crash hash logic
- [x] All 24 tests pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)