### PR TITLE
feat(ctd-core): align Rust schema with API schema

### DIFF
--- a/crates/ctd-core/src/crash_report.rs
+++ b/crates/ctd-core/src/crash_report.rs
@@ -1,129 +1,430 @@
-//! Crash report generation and serialization.
+//! Crash report types matching the API schema.
 //!
-//! This module handles creating and serializing crash reports for submission.
+//! These types exactly match the API's `createCrashReportSchema`.
 
 use serde::{Deserialize, Serialize};
 
-use crate::Result;
 use crate::load_order::LoadOrder;
+use crate::{CtdError, Result};
 
-/// Represents a crash report to be submitted.
+/// A crash report to be submitted to the API.
+///
+/// Matches the API's `createCrashReportSchema` exactly.
+/// Required fields are non-optional to enforce at compile time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CrashReport {
-    /// Unique identifier for this crash report.
-    pub id: Option<String>,
-    /// The game that crashed.
-    pub game: String,
-    /// Version of the game.
-    pub game_version: Option<String>,
-    /// The load order at the time of crash.
-    pub load_order: LoadOrder,
-    /// Optional crash log or stack trace.
-    pub crash_log: Option<String>,
-    /// Optional user-provided description.
-    pub description: Option<String>,
-    /// Timestamp when the crash occurred (Unix timestamp).
-    pub timestamp: Option<u64>,
+#[serde(rename_all = "camelCase")]
+pub struct CreateCrashReport {
+    /// Schema version for forward compatibility. Default: 1
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+
+    /// Game identifier (e.g., "skyrim-se", "fallout4").
+    /// Required, min length 1.
+    pub game_id: String,
+
+    /// Full stack trace from the crash.
+    /// Required, min length 1, max 100000.
+    pub stack_trace: String,
+
+    /// Pre-computed crash hash for deduplication.
+    /// Optional - server computes if not provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crash_hash: Option<String>,
+
+    /// Exception code (e.g., "0xC0000005").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exception_code: Option<String>,
+
+    /// Exception address (e.g., "0x7FF712345678").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exception_address: Option<String>,
+
+    /// Module that caused the crash (e.g., "SkyrimSE.exe").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub faulting_module: Option<String>,
+
+    /// Game version string (e.g., "1.6.1170").
+    /// Required, min length 1, max 50.
+    pub game_version: String,
+
+    /// Script extender version (e.g., "2.2.3").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub script_extender_version: Option<String>,
+
+    /// Operating system version.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub os_version: Option<String>,
+
+    /// Load order as JSON string. Required.
+    /// Use `LoadOrder::to_json()` to create this.
+    pub load_order_json: String,
+
+    /// Number of plugins in the load order.
+    /// Required, 0-10000.
+    pub plugin_count: u32,
+
+    /// Unix timestamp (milliseconds) when the crash occurred.
+    /// Required.
+    pub crashed_at: u64,
+
+    /// User notes about the crash.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
 }
 
-impl CrashReport {
-    /// Creates a new crash report with the given game and load order.
-    pub fn new(game: impl Into<String>, load_order: LoadOrder) -> Self {
-        Self {
-            id: None,
-            game: game.into(),
-            game_version: None,
-            load_order,
-            crash_log: None,
-            description: None,
-            timestamp: None,
-        }
+fn default_schema_version() -> u32 {
+    1
+}
+
+/// Response from the API after creating a crash report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CrashReportResponse {
+    /// The assigned report ID (ULID).
+    pub id: String,
+    /// Share token for accessing the report.
+    pub share_token: String,
+}
+
+/// Builder for creating crash reports with validation.
+#[derive(Debug, Default)]
+pub struct CrashReportBuilder {
+    game_id: Option<String>,
+    stack_trace: Option<String>,
+    crash_hash: Option<String>,
+    exception_code: Option<String>,
+    exception_address: Option<String>,
+    faulting_module: Option<String>,
+    game_version: Option<String>,
+    script_extender_version: Option<String>,
+    os_version: Option<String>,
+    load_order: Option<LoadOrder>,
+    crashed_at: Option<u64>,
+    notes: Option<String>,
+}
+
+impl CrashReportBuilder {
+    /// Creates a new builder.
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Sets the game version.
-    pub fn with_game_version(mut self, version: impl Into<String>) -> Self {
+    /// Sets the game ID (required).
+    pub fn game_id(mut self, id: impl Into<String>) -> Self {
+        self.game_id = Some(id.into());
+        self
+    }
+
+    /// Sets the stack trace (required).
+    pub fn stack_trace(mut self, trace: impl Into<String>) -> Self {
+        self.stack_trace = Some(trace.into());
+        self
+    }
+
+    /// Sets the crash hash (optional).
+    pub fn crash_hash(mut self, hash: impl Into<String>) -> Self {
+        self.crash_hash = Some(hash.into());
+        self
+    }
+
+    /// Sets the exception code (optional).
+    pub fn exception_code(mut self, code: impl Into<String>) -> Self {
+        self.exception_code = Some(code.into());
+        self
+    }
+
+    /// Sets the exception address (optional).
+    pub fn exception_address(mut self, addr: impl Into<String>) -> Self {
+        self.exception_address = Some(addr.into());
+        self
+    }
+
+    /// Sets the faulting module (optional).
+    pub fn faulting_module(mut self, module: impl Into<String>) -> Self {
+        self.faulting_module = Some(module.into());
+        self
+    }
+
+    /// Sets the game version (required).
+    pub fn game_version(mut self, version: impl Into<String>) -> Self {
         self.game_version = Some(version.into());
         self
     }
 
-    /// Sets the crash log.
-    pub fn with_crash_log(mut self, log: impl Into<String>) -> Self {
-        self.crash_log = Some(log.into());
+    /// Sets the script extender version (optional).
+    pub fn script_extender_version(mut self, version: impl Into<String>) -> Self {
+        self.script_extender_version = Some(version.into());
         self
     }
 
-    /// Sets the description.
-    pub fn with_description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
+    /// Sets the OS version (optional).
+    pub fn os_version(mut self, version: impl Into<String>) -> Self {
+        self.os_version = Some(version.into());
         self
     }
 
-    /// Sets the timestamp.
-    pub fn with_timestamp(mut self, timestamp: u64) -> Self {
-        self.timestamp = Some(timestamp);
+    /// Sets the load order (required).
+    pub fn load_order(mut self, lo: LoadOrder) -> Self {
+        self.load_order = Some(lo);
         self
     }
 
-    /// Serializes the crash report to JSON.
+    /// Sets the crash timestamp in milliseconds (required).
+    pub fn crashed_at(mut self, timestamp: u64) -> Self {
+        self.crashed_at = Some(timestamp);
+        self
+    }
+
+    /// Sets crash timestamp to now.
+    pub fn crashed_now(self) -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        self.crashed_at(now)
+    }
+
+    /// Sets user notes (optional).
+    pub fn notes(mut self, notes: impl Into<String>) -> Self {
+        self.notes = Some(notes.into());
+        self
+    }
+
+    /// Builds the crash report, validating all required fields.
     ///
     /// # Errors
     ///
-    /// Returns `CtdError::Serialize` if serialization fails.
+    /// Returns `CtdError::Validation` if required fields are missing or invalid.
+    pub fn build(self) -> Result<CreateCrashReport> {
+        let game_id = self
+            .game_id
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| CtdError::Validation("game_id is required".into()))?;
+
+        let stack_trace = self
+            .stack_trace
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| CtdError::Validation("stack_trace is required".into()))?;
+
+        if stack_trace.len() > 100_000 {
+            return Err(CtdError::Validation(
+                "stack_trace exceeds 100000 characters".into(),
+            ));
+        }
+
+        let game_version = self
+            .game_version
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| CtdError::Validation("game_version is required".into()))?;
+
+        if game_version.len() > 50 {
+            return Err(CtdError::Validation(
+                "game_version exceeds 50 characters".into(),
+            ));
+        }
+
+        let load_order = self
+            .load_order
+            .ok_or_else(|| CtdError::Validation("load_order is required".into()))?;
+
+        let plugin_count = load_order.len() as u32;
+        if plugin_count > 10_000 {
+            return Err(CtdError::Validation("plugin_count exceeds 10000".into()));
+        }
+
+        let load_order_json = load_order
+            .to_json()
+            .map_err(|e| CtdError::Validation(format!("failed to serialize load_order: {}", e)))?;
+
+        let crashed_at = self
+            .crashed_at
+            .ok_or_else(|| CtdError::Validation("crashed_at is required".into()))?;
+
+        // Validate optional field lengths
+        if let Some(ref hash) = self.crash_hash
+            && (hash.is_empty() || hash.len() > 64)
+        {
+            return Err(CtdError::Validation(
+                "crash_hash must be 1-64 characters".into(),
+            ));
+        }
+
+        if let Some(ref code) = self.exception_code
+            && code.len() > 50
+        {
+            return Err(CtdError::Validation(
+                "exception_code exceeds 50 characters".into(),
+            ));
+        }
+
+        if let Some(ref addr) = self.exception_address
+            && addr.len() > 50
+        {
+            return Err(CtdError::Validation(
+                "exception_address exceeds 50 characters".into(),
+            ));
+        }
+
+        if let Some(ref module) = self.faulting_module
+            && module.len() > 255
+        {
+            return Err(CtdError::Validation(
+                "faulting_module exceeds 255 characters".into(),
+            ));
+        }
+
+        if let Some(ref ver) = self.script_extender_version
+            && ver.len() > 50
+        {
+            return Err(CtdError::Validation(
+                "script_extender_version exceeds 50 characters".into(),
+            ));
+        }
+
+        if let Some(ref ver) = self.os_version
+            && ver.len() > 100
+        {
+            return Err(CtdError::Validation(
+                "os_version exceeds 100 characters".into(),
+            ));
+        }
+
+        if let Some(ref notes) = self.notes
+            && notes.len() > 5000
+        {
+            return Err(CtdError::Validation("notes exceeds 5000 characters".into()));
+        }
+
+        Ok(CreateCrashReport {
+            schema_version: 1,
+            game_id,
+            stack_trace,
+            crash_hash: self.crash_hash,
+            exception_code: self.exception_code,
+            exception_address: self.exception_address,
+            faulting_module: self.faulting_module,
+            game_version,
+            script_extender_version: self.script_extender_version,
+            os_version: self.os_version,
+            load_order_json,
+            plugin_count,
+            crashed_at,
+            notes: self.notes,
+        })
+    }
+}
+
+impl CreateCrashReport {
+    /// Creates a builder for constructing a crash report.
+    pub fn builder() -> CrashReportBuilder {
+        CrashReportBuilder::new()
+    }
+
+    /// Serializes to JSON for the API.
     pub fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(self)?)
-    }
-
-    /// Serializes the crash report to pretty-printed JSON.
-    ///
-    /// # Errors
-    ///
-    /// Returns `CtdError::Serialize` if serialization fails.
-    pub fn to_json_pretty(&self) -> Result<String> {
-        Ok(serde_json::to_string_pretty(self)?)
-    }
-
-    /// Deserializes a crash report from JSON.
-    ///
-    /// # Errors
-    ///
-    /// Returns `CtdError::Serialize` if deserialization fails.
-    pub fn from_json(json: &str) -> Result<Self> {
-        Ok(serde_json::from_str(json)?)
+        serde_json::to_string(self).map_err(CtdError::from)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::load_order::LoadOrderEntry;
 
-    #[test]
-    fn new_crash_report() {
-        let report = CrashReport::new("Skyrim", LoadOrder::new());
-        assert_eq!(report.game, "Skyrim");
-        assert!(report.load_order.is_empty());
-        assert!(report.id.is_none());
+    fn sample_load_order() -> LoadOrder {
+        let entries = vec![
+            LoadOrderEntry::full("Skyrim.esm", true, 0),
+            LoadOrderEntry::full("Update.esm", true, 1),
+        ];
+        LoadOrder::from_entries(entries)
     }
 
     #[test]
-    fn builder_pattern() {
-        let report = CrashReport::new("Skyrim", LoadOrder::new())
-            .with_game_version("1.6.1170")
-            .with_description("CTD on startup")
-            .with_timestamp(1700000000);
+    fn builder_creates_valid_report() {
+        let report = CreateCrashReport::builder()
+            .game_id("skyrim-se")
+            .game_version("1.6.1170")
+            .stack_trace("SkyrimSE.exe+0x12345")
+            .load_order(sample_load_order())
+            .crashed_at(1700000000000)
+            .build()
+            .unwrap();
 
-        assert_eq!(report.game_version, Some("1.6.1170".to_string()));
-        assert_eq!(report.description, Some("CTD on startup".to_string()));
-        assert_eq!(report.timestamp, Some(1700000000));
+        assert_eq!(report.game_id, "skyrim-se");
+        assert_eq!(report.game_version, "1.6.1170");
+        assert_eq!(report.plugin_count, 2);
+        assert_eq!(report.schema_version, 1);
     }
 
     #[test]
-    fn json_roundtrip() {
-        let report = CrashReport::new("Skyrim", LoadOrder::new()).with_game_version("1.6.1170");
+    fn builder_requires_game_id() {
+        let result = CreateCrashReport::builder()
+            .game_version("1.0")
+            .stack_trace("trace")
+            .load_order(LoadOrder::new())
+            .crashed_at(1000)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("game_id"));
+    }
+
+    #[test]
+    fn builder_requires_stack_trace() {
+        let result = CreateCrashReport::builder()
+            .game_id("skyrim-se")
+            .game_version("1.0")
+            .load_order(LoadOrder::new())
+            .crashed_at(1000)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("stack_trace"));
+    }
+
+    #[test]
+    fn builder_validates_field_lengths() {
+        let long_string = "x".repeat(51);
+        let result = CreateCrashReport::builder()
+            .game_id("skyrim-se")
+            .game_version(&long_string)
+            .stack_trace("trace")
+            .load_order(LoadOrder::new())
+            .crashed_at(1000)
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("game_version"));
+    }
+
+    #[test]
+    fn json_uses_camel_case() {
+        let report = CreateCrashReport::builder()
+            .game_id("skyrim-se")
+            .game_version("1.0")
+            .stack_trace("trace")
+            .load_order(LoadOrder::new())
+            .crashed_at(1000)
+            .build()
+            .unwrap();
 
         let json = report.to_json().unwrap();
-        let parsed = CrashReport::from_json(&json).unwrap();
 
-        assert_eq!(parsed.game, report.game);
-        assert_eq!(parsed.game_version, report.game_version);
+        assert!(json.contains("gameId"));
+        assert!(json.contains("gameVersion"));
+        assert!(json.contains("stackTrace"));
+        assert!(json.contains("loadOrderJson"));
+        assert!(json.contains("pluginCount"));
+        assert!(json.contains("crashedAt"));
+        assert!(json.contains("schemaVersion"));
+    }
+
+    #[test]
+    fn response_deserializes() {
+        let json = r#"{"id":"01ABC","shareToken":"xyz123"}"#;
+        let response: CrashReportResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(response.id, "01ABC");
+        assert_eq!(response.share_token, "xyz123");
     }
 }

--- a/crates/ctd-core/src/lib.rs
+++ b/crates/ctd-core/src/lib.rs
@@ -20,12 +20,16 @@ pub enum CtdError {
     #[error("Configuration error: {0}")]
     Config(String),
 
+    /// Validation failed for input data.
+    #[error("Validation error: {0}")]
+    Validation(String),
+
     /// Failed to parse a load order file or data.
     #[error("Failed to parse load order: {0}")]
     LoadOrderParse(String),
 
     /// Failed to serialize or deserialize data.
-    #[error("Failed to serialize crash report: {0}")]
+    #[error("Serialization error: {0}")]
     Serialize(#[from] serde_json::Error),
 
     /// An API request failed.

--- a/crates/ctd-core/src/load_order.rs
+++ b/crates/ctd-core/src/load_order.rs
@@ -1,78 +1,132 @@
-//! Load order parsing and management.
+//! Load order types matching the API schema.
 //!
-//! This module handles parsing and representing game mod load orders.
+//! These types represent mod load orders and are serialized to JSON
+//! for the `loadOrderJson` field in crash reports.
 
 use serde::{Deserialize, Serialize};
 
-use crate::Result;
-
-/// Represents a single entry in a load order.
+/// A single entry in a load order.
+///
+/// Matches the API's `loadOrderItemSchema`:
+/// - `name`: required string
+/// - `enabled`: optional boolean
+/// - `index`: optional integer
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadOrderEntry {
-    /// The name or identifier of the mod/plugin.
+    /// The name of the mod/plugin file (e.g., "SkyUI_SE.esp").
     pub name: String,
-    /// Whether this entry is enabled in the load order.
-    pub enabled: bool,
-    /// Optional index position in the load order.
-    pub index: Option<usize>,
+
+    /// Whether this plugin is enabled. Optional because some formats
+    /// don't track enabled state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    /// Position in the load order. Optional because some formats
+    /// are ordered implicitly by file position.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<u32>,
 }
 
 impl LoadOrderEntry {
-    /// Creates a new load order entry.
-    pub fn new(name: impl Into<String>, enabled: bool) -> Self {
+    /// Creates a new load order entry with just a name.
+    pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
-            enabled,
+            enabled: None,
             index: None,
         }
     }
 
-    /// Creates a new load order entry with a specific index.
-    pub fn with_index(name: impl Into<String>, enabled: bool, index: usize) -> Self {
+    /// Creates a new enabled/disabled entry.
+    pub fn with_enabled(name: impl Into<String>, enabled: bool) -> Self {
         Self {
             name: name.into(),
-            enabled,
+            enabled: Some(enabled),
+            index: None,
+        }
+    }
+
+    /// Creates a fully specified entry.
+    pub fn full(name: impl Into<String>, enabled: bool, index: u32) -> Self {
+        Self {
+            name: name.into(),
+            enabled: Some(enabled),
             index: Some(index),
         }
     }
 }
 
-/// Represents a complete load order.
+/// A complete load order as a list of entries.
+///
+/// This gets serialized to JSON and sent as the `loadOrderJson` string field.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadOrder {
-    /// The entries in the load order.
-    pub entries: Vec<LoadOrderEntry>,
-}
+#[serde(transparent)]
+pub struct LoadOrder(pub Vec<LoadOrderEntry>);
 
 impl LoadOrder {
     /// Creates a new empty load order.
     pub fn new() -> Self {
-        Self::default()
+        Self(Vec::new())
     }
 
-    /// Parses a load order from a string representation.
-    ///
-    /// # Errors
-    ///
-    /// Returns `CtdError::LoadOrderParse` if the input cannot be parsed.
-    pub fn parse(_input: &str) -> Result<Self> {
-        // TODO: Implement actual parsing logic
-        Ok(Self::new())
+    /// Creates a load order from a vector of entries.
+    pub fn from_entries(entries: Vec<LoadOrderEntry>) -> Self {
+        Self(entries)
     }
 
-    /// Returns the number of entries in the load order.
+    /// Returns the number of entries.
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.0.len()
     }
 
-    /// Returns true if the load order is empty.
+    /// Returns true if empty.
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.0.is_empty()
     }
 
-    /// Adds an entry to the load order.
+    /// Adds an entry.
     pub fn push(&mut self, entry: LoadOrderEntry) {
-        self.entries.push(entry);
+        self.0.push(entry);
+    }
+
+    /// Returns an iterator over entries.
+    pub fn iter(&self) -> impl Iterator<Item = &LoadOrderEntry> {
+        self.0.iter()
+    }
+
+    /// Serializes to JSON string for the API's `loadOrderJson` field.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(&self.0)
+    }
+
+    /// Deserializes from JSON string.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        let entries: Vec<LoadOrderEntry> = serde_json::from_str(json)?;
+        Ok(Self(entries))
+    }
+}
+
+impl IntoIterator for LoadOrder {
+    type Item = LoadOrderEntry;
+    type IntoIter = std::vec::IntoIter<LoadOrderEntry>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a LoadOrder {
+    type Item = &'a LoadOrderEntry;
+    type IntoIter = std::slice::Iter<'a, LoadOrderEntry>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl FromIterator<LoadOrderEntry> for LoadOrder {
+    fn from_iter<I: IntoIterator<Item = LoadOrderEntry>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
     }
 }
 
@@ -81,29 +135,53 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_load_order_is_empty() {
-        let lo = LoadOrder::new();
-        assert!(lo.is_empty());
-        assert_eq!(lo.len(), 0);
+    fn entry_minimal() {
+        let entry = LoadOrderEntry::new("Test.esp");
+        assert_eq!(entry.name, "Test.esp");
+        assert!(entry.enabled.is_none());
+        assert!(entry.index.is_none());
     }
 
     #[test]
-    fn push_entry() {
-        let mut lo = LoadOrder::new();
-        lo.push(LoadOrderEntry::new("test_mod", true));
-        assert_eq!(lo.len(), 1);
-        assert!(!lo.is_empty());
+    fn entry_with_enabled() {
+        let entry = LoadOrderEntry::with_enabled("Test.esp", true);
+        assert_eq!(entry.enabled, Some(true));
     }
 
     #[test]
-    fn entry_with_index() {
-        let entry = LoadOrderEntry::with_index("test_mod", true, 5);
+    fn entry_full() {
+        let entry = LoadOrderEntry::full("Test.esp", true, 5);
+        assert_eq!(entry.enabled, Some(true));
         assert_eq!(entry.index, Some(5));
     }
 
     #[test]
-    fn parse_returns_empty() {
-        let lo = LoadOrder::parse("").unwrap();
-        assert!(lo.is_empty());
+    fn load_order_json_roundtrip() {
+        let mut lo = LoadOrder::new();
+        lo.push(LoadOrderEntry::full("Skyrim.esm", true, 0));
+        lo.push(LoadOrderEntry::full("Update.esm", true, 1));
+        lo.push(LoadOrderEntry::with_enabled("SkyUI_SE.esp", true));
+
+        let json = lo.to_json().unwrap();
+        let parsed = LoadOrder::from_json(&json).unwrap();
+
+        assert_eq!(lo, parsed);
+    }
+
+    #[test]
+    fn json_skips_none_fields() {
+        let entry = LoadOrderEntry::new("Test.esp");
+        let json = serde_json::to_string(&entry).unwrap();
+
+        // Should not contain "enabled" or "index" keys
+        assert!(!json.contains("enabled"));
+        assert!(!json.contains("index"));
+    }
+
+    #[test]
+    fn collect_from_iter() {
+        let entries = vec![LoadOrderEntry::new("A.esp"), LoadOrderEntry::new("B.esp")];
+        let lo: LoadOrder = entries.into_iter().collect();
+        assert_eq!(lo.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

- Rewrites `LoadOrderEntry` and `LoadOrder` types to match API's `loadOrderItemSchema`
- Adds `CreateCrashReport` struct matching `createCrashReportSchema` with all fields and validation
- Adds `CrashReportResponse` for API response (id, share_token)
- Builder pattern with validation for all field constraints (lengths, required fields)
- Uses `serde rename_all = "camelCase"` for API compatibility
- Adds `CtdError::Validation` variant for builder validation errors

The Rust library now acts as a "gatekeeper" - game mods parse their specific formats, but must conform to ctd-core's validated schema.

Closes #7, closes #8

## Test plan

- [x] All 21 tests pass
- [x] cargo clippy passes
- [x] cargo fmt passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)