### PR TITLE
feat(ctd-cyberpunk): RED4ext plugin for Cyberpunk 2077 crash capture

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3,10 +3,41 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -15,16 +46,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "annotate-snippets",
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -43,6 +104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +123,61 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "const-combine"
+version = "0.1.0"
+source = "git+https://github.com/jac3km4/const-combine?rev=v0.1.4#1a3310b205964b72f8bb15223a4fd31285e7c1d2"
+
+[[package]]
+name = "const-crc32"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d13f542d70e5b339bf46f6f74704ac052cfd526c58cd87996bd1ef4615b9a0"
+
+[[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2066907075af649bcb8bcb1b9b986329b243677e6918b2d920aa64b0aac5ace3"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2",
+ "parking_lot",
+]
 
 [[package]]
 name = "ctd-core"
@@ -66,6 +191,31 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+]
+
+[[package]]
+name = "ctd-cyberpunk"
+version = "0.1.0"
+dependencies = [
+ "crash-context",
+ "crash-handler",
+ "ctd-core",
+ "minidump-writer",
+ "red4ext-rs",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "windows",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -101,10 +251,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-graph"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b920e777967421aa5f9bf34f842c0ab6ba19b3bdb4a082946093860f5858879"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "failspot"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c942e64b20ecd39933d5ff938ca4fdb6ef0d298cc3855b231179a5ef0b24948d"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -182,10 +369,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "goblin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -417,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +658,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +676,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -476,10 +711,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minidump-common"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dad3a7b1bd550c5f6f181b6b0fee6794f81aef6809e71467a6170ac2c0107b7"
+dependencies = [
+ "bitflags",
+ "debugid",
+ "num-derive",
+ "num-traits",
+ "range-map",
+ "scroll",
+ "smart-default",
+]
+
+[[package]]
+name = "minidump-writer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9370e1f326cb4385f78355d8a0f68f429e9002fd3ca53fff9b43fded234473"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "cfg-if",
+ "crash-context",
+ "error-graph",
+ "failspot",
+ "goblin",
+ "libc",
+ "log",
+ "mach2",
+ "memmap2",
+ "memoffset",
+ "minidump-common",
+ "nix",
+ "procfs-core",
+ "scroll",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -490,6 +801,48 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -546,6 +899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,12 +923,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -672,6 +1052,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-map"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a5a2d6c7039059af621472a4389be1215a816df61aa4d531cfe85264aee95f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "red4ext-rs"
+version = "0.10.0"
+source = "git+https://github.com/jac3km4/red4ext-rs#411ccf1cb85b3dc913034c2924d25701611f5138"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "const-combine",
+ "const-crc32",
+ "log",
+ "once_cell",
+ "sealed",
+ "thiserror",
+ "widestring",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +1095,35 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
@@ -750,6 +1184,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,10 +1244,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde"
@@ -894,6 +1381,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +1442,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1157,6 +1668,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1696,26 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1292,10 +1829,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["ctd-core"]
+members = ["ctd-core", "ctd-cyberpunk"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/ctd-cyberpunk/Cargo.toml
+++ b/crates/ctd-cyberpunk/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "ctd-cyberpunk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "RED4ext plugin for Cyberpunk 2077 crash capture and reporting"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Core CTD library
+ctd-core = { path = "../ctd-core" }
+
+# Async runtime for fire-and-forget API calls
+tokio = { version = "1", features = ["rt", "net", "sync"] }
+
+# Filesystem scanning
+walkdir = "2"
+
+# Error handling
+thiserror.workspace = true
+
+# Logging
+tracing.workspace = true
+
+# Windows-specific dependencies (including RED4ext which only builds on Windows)
+[target.'cfg(windows)'.dependencies]
+# RED4ext Rust bindings
+red4ext-rs = { git = "https://github.com/jac3km4/red4ext-rs", features = ["log"] }
+
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_Threading",
+    "Win32_System_LibraryLoader",
+    "Win32_System_ProcessStatus",
+    "Win32_System_SystemInformation",
+    "Win32_Storage_FileSystem",
+] }
+
+crash-handler = "0.6"
+crash-context = "0.6"
+minidump-writer = "0.10"

--- a/crates/ctd-cyberpunk/src/crash_handler.rs
+++ b/crates/ctd-cyberpunk/src/crash_handler.rs
@@ -1,0 +1,402 @@
+//! Vectored Exception Handler (VEH) for crash capture.
+//!
+//! This module registers a Windows VEH handler that captures fatal exceptions
+//! and triggers crash report submission.
+
+use std::sync::OnceLock;
+
+use thiserror::Error;
+
+use crate::report;
+
+/// Errors that can occur during crash handler operations.
+#[derive(Error, Debug)]
+pub enum CrashHandlerError {
+    /// The handler was already registered.
+    #[error("Crash handler already registered")]
+    AlreadyRegistered,
+
+    /// Failed to register the VEH handler.
+    #[error("Failed to register VEH handler: {0}")]
+    RegistrationFailed(String),
+
+    /// Failed to capture stack trace.
+    #[error("Failed to capture stack trace: {0}")]
+    StackTraceCapture(String),
+}
+
+/// Result type for crash handler operations.
+pub type Result<T> = std::result::Result<T, CrashHandlerError>;
+
+/// Captured data from a crash.
+#[derive(Debug, Clone)]
+pub struct CrashData {
+    /// The Windows exception code (e.g., 0xC0000005 for ACCESS_VIOLATION).
+    pub exception_code: u32,
+
+    /// The address where the exception occurred.
+    pub exception_address: u64,
+
+    /// The captured stack trace as a formatted string.
+    pub stack_trace: String,
+
+    /// Module name where the crash occurred (if available).
+    pub faulting_module: Option<String>,
+}
+
+/// Guard to ensure VEH is only registered once.
+static HANDLER_REGISTERED: OnceLock<()> = OnceLock::new();
+
+/// Registers the Vectored Exception Handler.
+///
+/// This should be called once during plugin initialization.
+/// Subsequent calls will return an error.
+///
+/// # Errors
+///
+/// Returns `CrashHandlerError::AlreadyRegistered` if already registered.
+/// Returns `CrashHandlerError::RegistrationFailed` if Windows API fails.
+#[cfg(windows)]
+pub fn register() -> Result<()> {
+    use windows::Win32::System::Diagnostics::Debug::AddVectoredExceptionHandler;
+
+    if HANDLER_REGISTERED.get().is_some() {
+        return Err(CrashHandlerError::AlreadyRegistered);
+    }
+
+    // SAFETY: We're registering a valid exception handler function.
+    // The handler must be careful not to allocate or do complex operations
+    // as the process state may be corrupted.
+    let result = unsafe { AddVectoredExceptionHandler(1, Some(veh_handler)) };
+
+    if result.is_null() {
+        return Err(CrashHandlerError::RegistrationFailed(
+            "AddVectoredExceptionHandler returned null".to_string(),
+        ));
+    }
+
+    // Mark as registered
+    let _ = HANDLER_REGISTERED.set(());
+
+    Ok(())
+}
+
+/// Non-Windows stub for register.
+#[cfg(not(windows))]
+pub fn register() -> Result<()> {
+    let _ = HANDLER_REGISTERED.set(());
+    Ok(())
+}
+
+/// The VEH handler callback.
+///
+/// This is called by Windows when an exception occurs. We filter for fatal
+/// exceptions and trigger crash report submission.
+#[cfg(windows)]
+unsafe extern "system" fn veh_handler(
+    exception_info: *mut windows::Win32::System::Diagnostics::Debug::EXCEPTION_POINTERS,
+) -> i32 {
+    use windows::Win32::System::Diagnostics::Debug::{
+        EXCEPTION_CONTINUE_SEARCH, EXCEPTION_POINTERS,
+    };
+
+    // SAFETY: Windows guarantees exception_info is valid when this callback is invoked
+    let info: &EXCEPTION_POINTERS = unsafe { &*exception_info };
+
+    let Some(record) = (unsafe { info.ExceptionRecord.as_ref() }) else {
+        return EXCEPTION_CONTINUE_SEARCH.0;
+    };
+
+    let code = record.ExceptionCode.0 as u32;
+
+    // Only handle fatal exceptions
+    if !is_fatal_exception(code) {
+        return EXCEPTION_CONTINUE_SEARCH.0;
+    }
+
+    // Capture crash data
+    // Note: We're in an exception handler, so we must be very careful
+    // about what we do here. Avoid allocations if possible.
+    let crash_data = CrashData {
+        exception_code: code,
+        exception_address: record.ExceptionAddress as u64,
+        stack_trace: capture_stack_trace(info),
+        faulting_module: get_module_at_address(record.ExceptionAddress as u64),
+    };
+
+    // Fire-and-forget report submission
+    // This spawns a thread to avoid blocking the exception handler
+    report::submit_async(crash_data);
+
+    // Continue searching for other handlers (let the game/debugger handle it too)
+    EXCEPTION_CONTINUE_SEARCH.0
+}
+
+/// Returns true if the exception code represents a fatal crash.
+#[cfg(windows)]
+fn is_fatal_exception(code: u32) -> bool {
+    // Common fatal exception codes
+    const ACCESS_VIOLATION: u32 = 0xC0000005;
+    const STACK_OVERFLOW: u32 = 0xC00000FD;
+    const ILLEGAL_INSTRUCTION: u32 = 0xC000001D;
+    const INTEGER_DIVIDE_BY_ZERO: u32 = 0xC0000094;
+    const INTEGER_OVERFLOW: u32 = 0xC0000095;
+    const PRIVILEGED_INSTRUCTION: u32 = 0xC0000096;
+    const IN_PAGE_ERROR: u32 = 0xC0000006;
+    const INVALID_HANDLE: u32 = 0xC0000008;
+    const HEAP_CORRUPTION: u32 = 0xC0000374;
+    const STACK_BUFFER_OVERRUN: u32 = 0xC0000409;
+
+    matches!(
+        code,
+        ACCESS_VIOLATION
+            | STACK_OVERFLOW
+            | ILLEGAL_INSTRUCTION
+            | INTEGER_DIVIDE_BY_ZERO
+            | INTEGER_OVERFLOW
+            | PRIVILEGED_INSTRUCTION
+            | IN_PAGE_ERROR
+            | INVALID_HANDLE
+            | HEAP_CORRUPTION
+            | STACK_BUFFER_OVERRUN
+    )
+}
+
+/// Captures a stack trace from the exception context.
+#[cfg(windows)]
+fn capture_stack_trace(
+    exception_info: &windows::Win32::System::Diagnostics::Debug::EXCEPTION_POINTERS,
+) -> String {
+    use std::fmt::Write;
+
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::Diagnostics::Debug::{
+        ADDRESS_MODE, CONTEXT, STACKFRAME64, StackWalk64,
+    };
+    use windows::Win32::System::LibraryLoader::{
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        GetModuleFileNameW, GetModuleHandleExW,
+    };
+    use windows::Win32::System::Threading::GetCurrentProcess;
+
+    let mut result = String::with_capacity(4096);
+
+    let Some(context) = (unsafe { exception_info.ContextRecord.as_ref() }) else {
+        return "Failed to get exception context".to_string();
+    };
+
+    // Get process handle
+    let process: HANDLE = unsafe { GetCurrentProcess() };
+
+    // Initialize stack frame from context
+    let mut frame = STACKFRAME64::default();
+
+    // x64 architecture
+    #[cfg(target_arch = "x86_64")]
+    {
+        frame.AddrPC.Offset = context.Rip;
+        frame.AddrPC.Mode = ADDRESS_MODE(3); // AddrModeFlat
+        frame.AddrFrame.Offset = context.Rbp;
+        frame.AddrFrame.Mode = ADDRESS_MODE(3);
+        frame.AddrStack.Offset = context.Rsp;
+        frame.AddrStack.Mode = ADDRESS_MODE(3);
+    }
+
+    let machine_type = 0x8664u32; // IMAGE_FILE_MACHINE_AMD64
+
+    // Walk the stack (limit to 64 frames to avoid infinite loops)
+    let mut frame_count = 0;
+    let max_frames = 64;
+
+    // Make a mutable copy of the context for StackWalk64
+    let mut context_copy: CONTEXT = *context;
+
+    while frame_count < max_frames {
+        // SAFETY: StackWalk64 is safe to call with valid handles and pointers
+        let success = unsafe {
+            StackWalk64(
+                machine_type,
+                process,
+                HANDLE::default(), // Use 0 for current thread in exception context
+                &mut frame,
+                std::ptr::addr_of_mut!(context_copy).cast(),
+                None,
+                None,
+                None,
+                None,
+            )
+        };
+
+        if !success.as_bool() {
+            break;
+        }
+
+        if frame.AddrPC.Offset == 0 {
+            break;
+        }
+
+        // Get module name for this address
+        let module_name =
+            get_module_at_address(frame.AddrPC.Offset).unwrap_or_else(|| "unknown".to_string());
+
+        // Calculate offset within module
+        let module_base = get_module_base(frame.AddrPC.Offset).unwrap_or(0);
+        let offset = frame.AddrPC.Offset.saturating_sub(module_base);
+
+        let _ = writeln!(
+            result,
+            "[{:2}] {}+0x{:X} (0x{:016X})",
+            frame_count, module_name, offset, frame.AddrPC.Offset
+        );
+
+        frame_count += 1;
+    }
+
+    if result.is_empty() {
+        // Fallback: just report the crash address
+        let Some(record) = (unsafe { exception_info.ExceptionRecord.as_ref() }) else {
+            return "Failed to capture stack trace".to_string();
+        };
+
+        let addr = record.ExceptionAddress as u64;
+        let module_name = get_module_at_address(addr).unwrap_or_else(|| "unknown".to_string());
+        let module_base = get_module_base(addr).unwrap_or(0);
+        let offset = addr.saturating_sub(module_base);
+
+        let _ = writeln!(
+            result,
+            "[0] {}+0x{:X} (0x{:016X})",
+            module_name, offset, addr
+        );
+    }
+
+    result
+}
+
+/// Non-Windows stub for stack trace capture.
+#[cfg(not(windows))]
+fn capture_stack_trace(_exception_info: &std::ffi::c_void) -> String {
+    "Stack trace not available on non-Windows platforms".to_string()
+}
+
+/// Gets the module name containing the given address.
+#[cfg(windows)]
+fn get_module_at_address(address: u64) -> Option<String> {
+    use windows::Win32::Foundation::HMODULE;
+    use windows::Win32::System::LibraryLoader::{
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        GetModuleFileNameW, GetModuleHandleExW,
+    };
+
+    let mut module: HMODULE = HMODULE::default();
+
+    // SAFETY: GetModuleHandleExW is safe with valid parameters
+    let success = unsafe {
+        GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            windows::core::PCWSTR::from_raw(address as *const u16),
+            &mut module,
+        )
+    };
+
+    if !success.is_ok() {
+        return None;
+    }
+
+    // Get module filename
+    let mut filename = [0u16; 260];
+    // SAFETY: GetModuleFileNameW is safe with valid buffer
+    let len = unsafe { GetModuleFileNameW(Some(module), &mut filename) };
+
+    if len == 0 {
+        return None;
+    }
+
+    let path = String::from_utf16_lossy(&filename[..len as usize]);
+
+    // Extract just the filename
+    path.rsplit('\\').next().map(|s| s.to_string())
+}
+
+/// Non-Windows stub.
+#[cfg(not(windows))]
+fn get_module_at_address(_address: u64) -> Option<String> {
+    None
+}
+
+/// Gets the base address of the module containing the given address.
+#[cfg(windows)]
+fn get_module_base(address: u64) -> Option<u64> {
+    use windows::Win32::Foundation::HMODULE;
+    use windows::Win32::System::LibraryLoader::{
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        GetModuleHandleExW,
+    };
+
+    let mut module: HMODULE = HMODULE::default();
+
+    // SAFETY: GetModuleHandleExW is safe with valid parameters
+    let success = unsafe {
+        GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            windows::core::PCWSTR::from_raw(address as *const u16),
+            &mut module,
+        )
+    };
+
+    if success.is_ok() {
+        Some(module.0 as u64)
+    } else {
+        None
+    }
+}
+
+/// Non-Windows stub.
+#[cfg(not(windows))]
+fn get_module_base(_address: u64) -> Option<u64> {
+    None
+}
+
+/// Returns a human-readable name for a Windows exception code.
+#[allow(dead_code)]
+pub fn exception_code_name(code: u32) -> &'static str {
+    match code {
+        0xC0000005 => "ACCESS_VIOLATION",
+        0xC00000FD => "STACK_OVERFLOW",
+        0xC000001D => "ILLEGAL_INSTRUCTION",
+        0xC0000094 => "INTEGER_DIVIDE_BY_ZERO",
+        0xC0000095 => "INTEGER_OVERFLOW",
+        0xC0000096 => "PRIVILEGED_INSTRUCTION",
+        0xC0000006 => "IN_PAGE_ERROR",
+        0xC0000008 => "INVALID_HANDLE",
+        0xC0000374 => "HEAP_CORRUPTION",
+        0xC0000409 => "STACK_BUFFER_OVERRUN",
+        _ => "UNKNOWN_EXCEPTION",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exception_code_name() {
+        assert_eq!(exception_code_name(0xC0000005), "ACCESS_VIOLATION");
+        assert_eq!(exception_code_name(0xC00000FD), "STACK_OVERFLOW");
+        assert_eq!(exception_code_name(0x12345678), "UNKNOWN_EXCEPTION");
+    }
+
+    #[test]
+    fn test_crash_data_clone() {
+        let data = CrashData {
+            exception_code: 0xC0000005,
+            exception_address: 0x7FF712345678,
+            stack_trace: "test trace".to_string(),
+            faulting_module: Some("test.dll".to_string()),
+        };
+
+        let cloned = data.clone();
+        assert_eq!(cloned.exception_code, data.exception_code);
+        assert_eq!(cloned.stack_trace, data.stack_trace);
+    }
+}

--- a/crates/ctd-cyberpunk/src/lib.rs
+++ b/crates/ctd-cyberpunk/src/lib.rs
@@ -1,0 +1,114 @@
+//! CTD Crash Reporter for Cyberpunk 2077
+//!
+//! This RED4ext plugin captures crashes via Windows Vectored Exception Handler
+//! and submits crash reports to the CTD backend API.
+//!
+//! ## Installation
+//!
+//! Place the compiled `ctd_cyberpunk.dll` in:
+//! `<game>/red4ext/plugins/ctd-cyberpunk/ctd_cyberpunk.dll`
+//!
+//! ## Features
+//!
+//! - Captures crashes with stack traces and exception information
+//! - Enumerates all installed mods from multiple sources
+//! - Fire-and-forget submission (never blocks the game)
+//! - Graceful failure (never crashes the crash handler)
+//!
+//! ## Platform Support
+//!
+//! This crate is designed for Windows (x86_64-pc-windows-msvc) but can be
+//! compiled on other platforms for development purposes. Non-Windows builds
+//! produce a stub library.
+
+// Allow dead code on non-Windows platforms where the actual implementation isn't used
+#![cfg_attr(not(windows), allow(dead_code, unused_imports))]
+
+pub mod crash_handler;
+pub mod mod_scanner;
+pub mod report;
+
+#[cfg(windows)]
+use red4ext_rs::{
+    Exportable, Plugin, PluginOps, SemVer, U16CStr, export_plugin_symbols, exports, wcstr,
+};
+
+#[cfg(windows)]
+use tracing::{error, info};
+
+/// The CTD Crash Reporter plugin for RED4ext.
+#[cfg(windows)]
+pub struct CtdReporter;
+
+#[cfg(windows)]
+impl Plugin for CtdReporter {
+    const AUTHOR: &'static U16CStr = wcstr!("ezmode-games");
+    const NAME: &'static U16CStr = wcstr!("CTD Crash Reporter");
+    const VERSION: SemVer = SemVer::new(0, 1, 0);
+
+    /// Called when the plugin is loaded.
+    ///
+    /// Initializes the VEH handler and caches the mod list.
+    fn on_init(env: &red4ext_rs::SdkEnv) {
+        // Initialize tracing to RED4ext logging
+        init_logging(env);
+
+        info!("CTD Crash Reporter initializing...");
+
+        // Register VEH handler for crash capture
+        if let Err(e) = crash_handler::register() {
+            error!("Failed to register crash handler: {}", e);
+        } else {
+            info!("VEH crash handler registered");
+        }
+
+        // Cache mod list on startup (filesystem scan is expensive)
+        match mod_scanner::scan_and_cache() {
+            Ok(count) => info!("Cached {} mods from all sources", count),
+            Err(e) => error!("Failed to scan mods: {}", e),
+        }
+
+        info!("CTD Crash Reporter initialized successfully");
+    }
+
+    fn exports() -> impl Exportable {
+        // No exported functions needed - we only handle crashes
+        exports![]
+    }
+}
+
+/// Initialize tracing to output to RED4ext's logging system.
+#[cfg(windows)]
+fn init_logging(_env: &red4ext_rs::SdkEnv) {
+    // red4ext-rs with the "log" feature handles this automatically
+    // via the tracing subscriber integration
+}
+
+#[cfg(windows)]
+export_plugin_symbols!(CtdReporter);
+
+// ===========================================================================
+// Non-Windows stubs for development/testing on other platforms
+// ===========================================================================
+
+/// Stub initialization function for non-Windows platforms.
+///
+/// This is only used for development testing - the actual plugin
+/// functionality only works on Windows.
+#[cfg(not(windows))]
+pub fn init() {
+    eprintln!("ctd-cyberpunk: This plugin only works on Windows");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mod_scanner_types() {
+        // Basic smoke test that types are correct
+        use mod_scanner::ModType;
+        let _archive = ModType::Archive;
+        let _redmod = ModType::RedMod;
+    }
+}

--- a/crates/ctd-cyberpunk/src/mod_scanner.rs
+++ b/crates/ctd-cyberpunk/src/mod_scanner.rs
@@ -1,0 +1,399 @@
+//! Mod enumeration for Cyberpunk 2077.
+//!
+//! This module scans all known mod locations to build a complete load order
+//! for inclusion in crash reports.
+//!
+//! ## Supported Mod Types
+//!
+//! - **Archive**: `.archive` files in `archive/pc/mod/`
+//! - **REDmod**: Directories with `info.json` in `mods/`
+//! - **RED4ext**: `.dll` plugins in `red4ext/plugins/`
+//! - **CET**: Lua mods with `init.lua` in `bin/x64/plugins/cyber_engine_tweaks/mods/`
+//! - **Redscript**: `.reds` scripts in `r6/scripts/`
+//! - **TweakXL**: `.yaml`/`.yml` files in `r6/tweaks/`
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use ctd_core::load_order::{LoadOrder, LoadOrderEntry};
+use thiserror::Error;
+use tracing::{debug, warn};
+use walkdir::WalkDir;
+
+/// Errors that can occur during mod scanning.
+#[derive(Error, Debug)]
+pub enum ModScannerError {
+    /// Failed to determine the game directory.
+    #[error("Could not determine game directory")]
+    GameDirectoryNotFound,
+
+    /// Failed to read a mod directory.
+    #[error("Failed to read mod directory {path}: {source}")]
+    DirectoryRead {
+        path: String,
+        source: std::io::Error,
+    },
+}
+
+/// Result type for mod scanner operations.
+pub type Result<T> = std::result::Result<T, ModScannerError>;
+
+/// Types of mods in Cyberpunk 2077.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModType {
+    /// Archive files (`.archive`) for game assets.
+    Archive,
+    /// REDmod official modding format.
+    RedMod,
+    /// RED4ext DLL plugins.
+    Red4ext,
+    /// Cyber Engine Tweaks Lua mods.
+    Cet,
+    /// Redscript (`.reds`) script mods.
+    Redscript,
+    /// TweakXL (`.yaml`/`.yml`) tweak files.
+    TweakXL,
+}
+
+impl ModType {
+    /// Returns the prefix used in load order entries for this mod type.
+    fn prefix(self) -> &'static str {
+        match self {
+            ModType::Archive => "",
+            ModType::RedMod => "[REDmod]",
+            ModType::Red4ext => "[RED4ext]",
+            ModType::Cet => "[CET]",
+            ModType::Redscript => "[Redscript]",
+            ModType::TweakXL => "[TweakXL]",
+        }
+    }
+}
+
+/// Mod paths relative to the game directory, with their type.
+const MOD_PATHS: &[(&str, ModType)] = &[
+    ("archive/pc/mod", ModType::Archive),
+    ("mods", ModType::RedMod),
+    ("red4ext/plugins", ModType::Red4ext),
+    ("bin/x64/plugins/cyber_engine_tweaks/mods", ModType::Cet),
+    ("r6/scripts", ModType::Redscript),
+    ("r6/tweaks", ModType::TweakXL),
+];
+
+/// Cached mod list from startup scan.
+static CACHED_MODS: OnceLock<LoadOrder> = OnceLock::new();
+
+/// Scans all mod locations and caches the result.
+///
+/// This should be called once during plugin initialization.
+/// Subsequent calls will return the cached count without rescanning.
+///
+/// # Returns
+///
+/// The number of mods found, or an error if scanning failed.
+pub fn scan_and_cache() -> Result<usize> {
+    if let Some(cached) = CACHED_MODS.get() {
+        return Ok(cached.len());
+    }
+
+    let mods = scan_mods()?;
+    let count = mods.len();
+
+    // Store in cache (if another thread beat us, that's fine)
+    let _ = CACHED_MODS.set(mods);
+
+    Ok(count)
+}
+
+/// Returns the cached mod list.
+///
+/// # Panics
+///
+/// Panics if `scan_and_cache()` was not called first.
+pub fn get_cached() -> &'static LoadOrder {
+    CACHED_MODS
+        .get()
+        .expect("Mods not scanned yet - call scan_and_cache() first")
+}
+
+/// Returns a clone of the cached mod list, or an empty list if not scanned.
+pub fn get_cached_or_empty() -> LoadOrder {
+    CACHED_MODS.get().cloned().unwrap_or_default()
+}
+
+/// Scans all mod locations and returns a LoadOrder.
+fn scan_mods() -> Result<LoadOrder> {
+    let game_dir = get_game_directory()?;
+    let mut entries = Vec::new();
+    let mut index = 0u32;
+
+    debug!("Scanning mods in game directory: {:?}", game_dir);
+
+    for (path, mod_type) in MOD_PATHS {
+        let full_path = game_dir.join(path);
+
+        if !full_path.exists() {
+            debug!("Mod path does not exist: {:?}", full_path);
+            continue;
+        }
+
+        let count_before = entries.len();
+
+        match mod_type {
+            ModType::Archive => {
+                scan_archive_mods(&full_path, &mut entries, &mut index);
+            }
+            ModType::RedMod => {
+                scan_redmod_mods(&full_path, &mut entries, &mut index);
+            }
+            ModType::Red4ext => {
+                scan_red4ext_mods(&full_path, &mut entries, &mut index);
+            }
+            ModType::Cet => {
+                scan_cet_mods(&full_path, &mut entries, &mut index);
+            }
+            ModType::Redscript => {
+                scan_redscript_mods(&full_path, &mut entries, &mut index);
+            }
+            ModType::TweakXL => {
+                scan_tweakxl_mods(&full_path, &mut entries, &mut index);
+            }
+        }
+
+        let count_found = entries.len() - count_before;
+        if count_found > 0 {
+            debug!("Found {} {:?} mods in {:?}", count_found, mod_type, path);
+        }
+    }
+
+    Ok(LoadOrder::from_entries(entries))
+}
+
+/// Scans for Archive mods (`.archive` files).
+fn scan_archive_mods(path: &Path, entries: &mut Vec<LoadOrderEntry>, index: &mut u32) {
+    for entry in WalkDir::new(path).max_depth(1).into_iter().flatten() {
+        let file_path = entry.path();
+        if file_path.extension().is_some_and(|ext| ext == "archive") {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            entries.push(LoadOrderEntry::full(name, true, *index));
+            *index += 1;
+        }
+    }
+}
+
+/// Scans for REDmod mods (directories with `info.json`).
+fn scan_redmod_mods(path: &Path, entries: &mut Vec<LoadOrderEntry>, index: &mut u32) {
+    // REDmod mods are directories containing info.json
+    for entry in WalkDir::new(path).max_depth(2).into_iter().flatten() {
+        let file_path = entry.path();
+        if entry.file_name() == "info.json"
+            && let Some(mod_dir) = file_path.parent()
+            && let Some(mod_name) = mod_dir.file_name()
+        {
+            let name = format!(
+                "{} {}",
+                ModType::RedMod.prefix(),
+                mod_name.to_string_lossy()
+            );
+            entries.push(LoadOrderEntry::full(name, true, *index));
+            *index += 1;
+        }
+    }
+}
+
+/// Scans for RED4ext plugins (`.dll` files).
+fn scan_red4ext_mods(path: &Path, entries: &mut Vec<LoadOrderEntry>, index: &mut u32) {
+    // RED4ext plugins are DLLs, typically in subdirectories
+    for entry in WalkDir::new(path).max_depth(2).into_iter().flatten() {
+        let file_path = entry.path();
+        if file_path.extension().is_some_and(|ext| ext == "dll") {
+            // Skip our own DLL
+            let filename = entry.file_name().to_string_lossy();
+            if filename.contains("ctd_cyberpunk") || filename.contains("ctd-cyberpunk") {
+                continue;
+            }
+
+            let name = format!("{} {}", ModType::Red4ext.prefix(), filename);
+            entries.push(LoadOrderEntry::full(name, true, *index));
+            *index += 1;
+        }
+    }
+}
+
+/// Scans for CET mods (directories with `init.lua`).
+fn scan_cet_mods(path: &Path, entries: &mut Vec<LoadOrderEntry>, index: &mut u32) {
+    // CET mods are directories containing init.lua
+    for entry in WalkDir::new(path).max_depth(2).into_iter().flatten() {
+        if entry.file_name() == "init.lua"
+            && let Some(mod_dir) = entry.path().parent()
+            && let Some(mod_name) = mod_dir.file_name()
+        {
+            let name = format!("{} {}", ModType::Cet.prefix(), mod_name.to_string_lossy());
+            entries.push(LoadOrderEntry::full(name, true, *index));
+            *index += 1;
+        }
+    }
+}
+
+/// Scans for Redscript mods (`.reds` files).
+fn scan_redscript_mods(path: &Path, entries: &mut Vec<LoadOrderEntry>, index: &mut u32) {
+    // Collect unique script directories/files
+    let mut seen_mods = std::collections::HashSet::new();
+
+    for entry in WalkDir::new(path).into_iter().flatten() {
+        let file_path = entry.path();
+        if file_path.extension().is_some_and(|ext| ext == "reds") {
+            // Use parent directory as mod name if it exists, otherwise file name
+            let mod_name = if let Some(parent) = file_path.parent() {
+                if parent != path {
+                    // Use the immediate parent directory name
+                    parent
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| entry.file_name().to_string_lossy().into_owned())
+                } else {
+                    entry.file_name().to_string_lossy().into_owned()
+                }
+            } else {
+                entry.file_name().to_string_lossy().into_owned()
+            };
+
+            // Only add each mod directory once
+            if seen_mods.insert(mod_name.clone()) {
+                let name = format!("{} {}", ModType::Redscript.prefix(), mod_name);
+                entries.push(LoadOrderEntry::full(name, true, *index));
+                *index += 1;
+            }
+        }
+    }
+}
+
+/// Scans for TweakXL mods (`.yaml`/`.yml` files).
+fn scan_tweakxl_mods(path: &Path, entries: &mut Vec<LoadOrderEntry>, index: &mut u32) {
+    // Collect unique tweak directories/files
+    let mut seen_mods = std::collections::HashSet::new();
+
+    for entry in WalkDir::new(path).into_iter().flatten() {
+        let file_path = entry.path();
+        if file_path
+            .extension()
+            .is_some_and(|ext| ext == "yaml" || ext == "yml")
+        {
+            // Use parent directory as mod name if it exists
+            let mod_name = if let Some(parent) = file_path.parent() {
+                if parent != path {
+                    parent
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| entry.file_name().to_string_lossy().into_owned())
+                } else {
+                    entry.file_name().to_string_lossy().into_owned()
+                }
+            } else {
+                entry.file_name().to_string_lossy().into_owned()
+            };
+
+            // Only add each mod directory once
+            if seen_mods.insert(mod_name.clone()) {
+                let name = format!("{} {}", ModType::TweakXL.prefix(), mod_name);
+                entries.push(LoadOrderEntry::full(name, true, *index));
+                *index += 1;
+            }
+        }
+    }
+}
+
+/// Gets the game directory from the current DLL location.
+///
+/// The plugin DLL is expected to be at:
+/// `<game>/red4ext/plugins/ctd-cyberpunk/ctd_cyberpunk.dll`
+///
+/// So we walk up 4 directory levels to get the game root.
+#[cfg(windows)]
+fn get_game_directory() -> Result<PathBuf> {
+    use windows::Win32::Foundation::HMODULE;
+    use windows::Win32::System::LibraryLoader::GetModuleFileNameW;
+
+    // Get the path to our own DLL
+    let mut path_buf = [0u16; 260];
+
+    // SAFETY: GetModuleFileNameW with null module returns the current module path
+    let len = unsafe { GetModuleFileNameW(HMODULE::default(), &mut path_buf) };
+
+    if len == 0 {
+        warn!("GetModuleFileNameW failed, falling back to current_exe");
+        return get_game_directory_fallback();
+    }
+
+    let dll_path = String::from_utf16_lossy(&path_buf[..len as usize]);
+    let dll_path = PathBuf::from(dll_path);
+
+    // Walk up from red4ext/plugins/ctd-cyberpunk/ctd_cyberpunk.dll to game root
+    // That's 4 levels up: file -> ctd-cyberpunk -> plugins -> red4ext -> game
+    dll_path
+        .parent() // ctd-cyberpunk/
+        .and_then(|p| p.parent()) // plugins/
+        .and_then(|p| p.parent()) // red4ext/
+        .and_then(|p| p.parent()) // game root
+        .map(|p| p.to_path_buf())
+        .ok_or(ModScannerError::GameDirectoryNotFound)
+}
+
+/// Fallback method using current_exe.
+#[cfg(windows)]
+fn get_game_directory_fallback() -> Result<PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        .ok_or(ModScannerError::GameDirectoryNotFound)
+}
+
+/// Non-Windows stub - returns current directory.
+#[cfg(not(windows))]
+fn get_game_directory() -> Result<PathBuf> {
+    std::env::current_dir().map_err(|_| ModScannerError::GameDirectoryNotFound)
+}
+
+/// Gets the game directory path for internal use by other modules.
+///
+/// This is a public accessor for the private `get_game_directory` function.
+pub(crate) fn get_game_directory_path() -> Option<PathBuf> {
+    get_game_directory().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mod_type_prefix() {
+        assert_eq!(ModType::Archive.prefix(), "");
+        assert_eq!(ModType::RedMod.prefix(), "[REDmod]");
+        assert_eq!(ModType::Red4ext.prefix(), "[RED4ext]");
+        assert_eq!(ModType::Cet.prefix(), "[CET]");
+        assert_eq!(ModType::Redscript.prefix(), "[Redscript]");
+        assert_eq!(ModType::TweakXL.prefix(), "[TweakXL]");
+    }
+
+    #[test]
+    fn test_mod_paths_coverage() {
+        // Ensure we have all 6 mod locations covered
+        assert_eq!(MOD_PATHS.len(), 6);
+
+        let types: Vec<ModType> = MOD_PATHS.iter().map(|(_, t)| *t).collect();
+        assert!(types.contains(&ModType::Archive));
+        assert!(types.contains(&ModType::RedMod));
+        assert!(types.contains(&ModType::Red4ext));
+        assert!(types.contains(&ModType::Cet));
+        assert!(types.contains(&ModType::Redscript));
+        assert!(types.contains(&ModType::TweakXL));
+    }
+
+    #[test]
+    fn test_get_cached_or_empty() {
+        // Should return empty if not scanned
+        // Note: This test may fail if run after scan_and_cache is called elsewhere
+        let result = get_cached_or_empty();
+        // Just verify it doesn't panic and returns a valid LoadOrder
+        let _ = result.len();
+    }
+}

--- a/crates/ctd-cyberpunk/src/report.rs
+++ b/crates/ctd-cyberpunk/src/report.rs
@@ -1,0 +1,326 @@
+//! Crash report building and submission.
+//!
+//! This module handles creating crash reports from captured crash data
+//! and submitting them to the CTD API.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use ctd_core::api_client::ApiClient;
+use ctd_core::crash_report::CreateCrashReport;
+use thiserror::Error;
+use tracing::{debug, error, info, warn};
+
+use crate::crash_handler::CrashData;
+use crate::mod_scanner;
+
+/// Errors that can occur during report submission.
+#[derive(Error, Debug)]
+pub enum ReportError {
+    /// Failed to build the crash report.
+    #[error("Failed to build crash report: {0}")]
+    BuildFailed(String),
+
+    /// Failed to create the API client.
+    #[error("Failed to create API client: {0}")]
+    ClientCreation(String),
+
+    /// Failed to submit the report.
+    #[error("Failed to submit crash report: {0}")]
+    Submission(String),
+
+    /// A submission is already in progress.
+    #[error("Crash report submission already in progress")]
+    AlreadySubmitting,
+}
+
+/// Result type for report operations.
+pub type Result<T> = std::result::Result<T, ReportError>;
+
+/// Guard to prevent multiple simultaneous submissions.
+static SUBMISSION_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Game ID for Cyberpunk 2077 crash reports.
+const GAME_ID: &str = "cyberpunk-2077";
+
+/// Submits a crash report asynchronously (fire-and-forget).
+///
+/// This spawns a new thread to handle submission, avoiding blocking
+/// the exception handler. If a submission is already in progress,
+/// this call is ignored.
+///
+/// # Arguments
+///
+/// * `crash_data` - The captured crash data to report.
+pub fn submit_async(crash_data: CrashData) {
+    // Check if we're already submitting
+    if SUBMISSION_IN_PROGRESS
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        warn!("Crash report submission already in progress, skipping duplicate");
+        return;
+    }
+
+    // Spawn a thread for submission
+    // We use a thread instead of tokio::spawn because we may not have
+    // a runtime active, and we want to guarantee this doesn't block
+    std::thread::spawn(move || {
+        let result = submit_sync(crash_data);
+
+        // Reset the in-progress flag
+        SUBMISSION_IN_PROGRESS.store(false, Ordering::SeqCst);
+
+        match result {
+            Ok(response_id) => {
+                info!("Crash report submitted successfully: {}", response_id);
+            }
+            Err(e) => {
+                // Log but don't crash - we're in a crash handler after all
+                error!("Failed to submit crash report: {}", e);
+            }
+        }
+    });
+}
+
+/// Submits a crash report synchronously.
+///
+/// This creates a tokio runtime to execute the async API call.
+///
+/// # Returns
+///
+/// The report ID on success, or an error on failure.
+fn submit_sync(crash_data: CrashData) -> Result<String> {
+    debug!(
+        "Submitting crash report for exception 0x{:08X}",
+        crash_data.exception_code
+    );
+
+    // Get cached mods (or empty if not scanned)
+    let load_order = mod_scanner::get_cached_or_empty();
+
+    // Build the crash report
+    let report = build_report(&crash_data, load_order)?;
+
+    // Create a single-threaded runtime for the API call
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| ReportError::Submission(format!("Failed to create runtime: {}", e)))?;
+
+    // Execute the API call
+    let response = rt.block_on(async {
+        let client = ApiClient::from_config()
+            .or_else(|_| ApiClient::with_defaults())
+            .map_err(|e| ReportError::ClientCreation(e.to_string()))?;
+
+        client
+            .submit_crash_report(&report)
+            .await
+            .map_err(|e| ReportError::Submission(e.to_string()))
+    })?;
+
+    Ok(response.id)
+}
+
+/// Builds a crash report from crash data.
+fn build_report(
+    crash_data: &CrashData,
+    load_order: ctd_core::load_order::LoadOrder,
+) -> Result<CreateCrashReport> {
+    let mut builder = CreateCrashReport::builder()
+        .game_id(GAME_ID)
+        .game_version(get_game_version())
+        .stack_trace(&crash_data.stack_trace)
+        .exception_code(format!("0x{:08X}", crash_data.exception_code))
+        .exception_address(format!("0x{:016X}", crash_data.exception_address))
+        .load_order(load_order)
+        .crashed_now();
+
+    // Add faulting module if available
+    if let Some(ref module) = crash_data.faulting_module {
+        builder = builder.faulting_module(module);
+    }
+
+    // Add RED4ext version if we can detect it
+    if let Some(version) = get_red4ext_version() {
+        builder = builder.script_extender_version(version);
+    }
+
+    // Add OS version
+    if let Some(os_version) = get_os_version() {
+        builder = builder.os_version(os_version);
+    }
+
+    builder
+        .build()
+        .map_err(|e| ReportError::BuildFailed(e.to_string()))
+}
+
+/// Gets the Cyberpunk 2077 game version.
+///
+/// Attempts to read the version from the game executable.
+/// Falls back to "unknown" if detection fails.
+fn get_game_version() -> String {
+    // Try to detect version from game files
+    #[cfg(windows)]
+    if let Some(version) = detect_game_version_windows() {
+        return version;
+    }
+
+    // Fallback to unknown
+    "unknown".to_string()
+}
+
+/// Attempts to detect the game version on Windows.
+#[cfg(windows)]
+fn detect_game_version_windows() -> Option<String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows::Win32::Storage::FileSystem::{
+        GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
+    };
+    use windows::core::PCWSTR;
+
+    let game_dir = mod_scanner::get_game_directory_path()?;
+    let exe_path = game_dir.join("bin/x64/Cyberpunk2077.exe");
+
+    if !exe_path.exists() {
+        return None;
+    }
+
+    // Convert path to wide string
+    let wide_path: Vec<u16> = OsStr::new(&exe_path)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let path_pcwstr = PCWSTR::from_raw(wide_path.as_ptr());
+
+    // Get version info size
+    let size = unsafe { GetFileVersionInfoSizeW(path_pcwstr, None) };
+    if size == 0 {
+        return None;
+    }
+
+    // Allocate buffer and get version info
+    let mut buffer = vec![0u8; size as usize];
+    let result = unsafe { GetFileVersionInfoW(path_pcwstr, 0, size, buffer.as_mut_ptr().cast()) };
+
+    if !result.as_bool() {
+        return None;
+    }
+
+    // Query the root block for VS_FIXEDFILEINFO
+    let mut info_ptr: *mut std::ffi::c_void = std::ptr::null_mut();
+    let mut info_len: u32 = 0;
+
+    let query_path: Vec<u16> = OsStr::new("\\")
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let result = unsafe {
+        VerQueryValueW(
+            buffer.as_ptr().cast(),
+            PCWSTR::from_raw(query_path.as_ptr()),
+            &mut info_ptr,
+            &mut info_len,
+        )
+    };
+
+    if !result.as_bool() || info_ptr.is_null() {
+        return None;
+    }
+
+    // VS_FIXEDFILEINFO structure
+    #[repr(C)]
+    struct VsFixedFileInfo {
+        dw_signature: u32,
+        dw_struc_version: u32,
+        dw_file_version_ms: u32,
+        dw_file_version_ls: u32,
+        // ... other fields we don't need
+    }
+
+    let info = unsafe { &*(info_ptr as *const VsFixedFileInfo) };
+
+    // Extract version numbers
+    let major = (info.dw_file_version_ms >> 16) & 0xFFFF;
+    let minor = info.dw_file_version_ms & 0xFFFF;
+    let patch = (info.dw_file_version_ls >> 16) & 0xFFFF;
+    let build = info.dw_file_version_ls & 0xFFFF;
+
+    Some(format!("{}.{}.{}.{}", major, minor, patch, build))
+}
+
+/// Gets the RED4ext version if available.
+///
+/// RED4ext doesn't expose a Rust-friendly version API yet,
+/// so this returns None for now.
+fn get_red4ext_version() -> Option<String> {
+    // RED4ext doesn't expose a Rust-friendly version API yet
+    // This would need to be implemented using the SDK
+    None
+}
+
+/// Gets the Windows version string.
+#[cfg(windows)]
+fn get_os_version() -> Option<String> {
+    use windows::Win32::System::SystemInformation::{GetVersionExW, OSVERSIONINFOW};
+
+    let mut info = OSVERSIONINFOW::default();
+    info.dwOSVersionInfoSize = std::mem::size_of::<OSVERSIONINFOW>() as u32;
+
+    // SAFETY: GetVersionExW is safe with a properly sized OSVERSIONINFOW
+    #[allow(deprecated)]
+    let result = unsafe { GetVersionExW(&mut info) };
+
+    if result.as_bool() {
+        Some(format!(
+            "Windows {}.{}.{}",
+            info.dwMajorVersion, info.dwMinorVersion, info.dwBuildNumber
+        ))
+    } else {
+        None
+    }
+}
+
+/// Non-Windows stub.
+#[cfg(not(windows))]
+fn get_os_version() -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ctd_core::load_order::LoadOrder;
+
+    #[test]
+    fn test_build_report() {
+        let crash_data = CrashData {
+            exception_code: 0xC0000005,
+            exception_address: 0x7FF712345678,
+            stack_trace: "test stack trace".to_string(),
+            faulting_module: Some("test.dll".to_string()),
+        };
+
+        let load_order = LoadOrder::new();
+        let result = build_report(&crash_data, load_order);
+
+        assert!(result.is_ok());
+        let report = result.unwrap();
+        assert_eq!(report.game_id, GAME_ID);
+        assert_eq!(report.exception_code, Some("0xC0000005".to_string()));
+        assert_eq!(
+            report.exception_address,
+            Some("0x00007FF712345678".to_string())
+        );
+    }
+
+    #[test]
+    fn test_game_id_constant() {
+        assert_eq!(GAME_ID, "cyberpunk-2077");
+    }
+}


### PR DESCRIPTION
## Summary

- Implements RED4ext plugin for Cyberpunk 2077 crash capture (pure Rust via red4ext-rs)
- Registers Vectored Exception Handler for fatal crash detection
- Scans 6 mod types: Archive, REDmod, RED4ext, CET, Redscript, TweakXL
- Fire-and-forget API submission to avoid blocking crash handler

## Test plan

- [x] Builds on Linux with `cfg(windows)` guards
- [x] All 29 tests pass
- [x] Clippy clean
- [ ] Cross-compile for `x86_64-pc-windows-msvc`
- [ ] Test with RED4ext in Cyberpunk 2077

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)