### PR TITLE
feat(api): add API key management

### DIFF
--- a/api/drizzle/0001_api_keys.sql
+++ b/api/drizzle/0001_api_keys.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `api_key` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text,
+	`name` text DEFAULT 'default' NOT NULL,
+	`key_hash` text NOT NULL,
+	`key_prefix` text NOT NULL,
+	`last_used_at` integer,
+	`expires_at` integer,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `api_key_key_hash_unique` ON `api_key` (`key_hash`);

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
 			"when": 1765955418351,
 			"tag": "0000_clean_scream",
 			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1765955500000,
+			"tag": "0001_api_keys",
+			"breakpoints": true
 		}
 	]
 }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { requestId } from 'hono/request-id';
 
+import { apiKeys } from '@/routes/api-keys';
 import { crashes } from '@/routes/crashes';
 
 const app = new Hono();
@@ -16,6 +17,7 @@ app.get('/health', (c) => {
 });
 
 // Routes
+app.route('/api-keys', apiKeys);
 app.route('/crashes', crashes);
 
 // Error handler

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -39,6 +39,19 @@ export const crashReport = sqliteTable('crash_report', {
 		.default(sql`(unixepoch() * 1000)`),
 });
 
+export const apiKey = sqliteTable('api_key', {
+	id: text('id').primaryKey(), // ULID
+	userId: text('user_id'), // Optional - for future user association
+	name: text('name').notNull().default('default'),
+	keyHash: text('key_hash').notNull().unique(), // SHA-256 hash of key
+	keyPrefix: text('key_prefix').notNull(), // First 8 chars for identification (ctd_xxxx)
+	lastUsedAt: integer('last_used_at', { mode: 'timestamp_ms' }),
+	expiresAt: integer('expires_at', { mode: 'timestamp_ms' }),
+	createdAt: integer('created_at', { mode: 'timestamp_ms' })
+		.notNull()
+		.default(sql`(unixepoch() * 1000)`),
+});
+
 export const crashPattern = sqliteTable('crash_pattern', {
 	id: text('id').primaryKey(), // ULID
 	gameId: text('game_id').notNull(),
@@ -64,3 +77,5 @@ export type CrashReport = typeof crashReport.$inferSelect;
 export type NewCrashReport = typeof crashReport.$inferInsert;
 export type CrashPattern = typeof crashPattern.$inferSelect;
 export type NewCrashPattern = typeof crashPattern.$inferInsert;
+export type ApiKey = typeof apiKey.$inferSelect;
+export type NewApiKey = typeof apiKey.$inferInsert;

--- a/api/src/lib/api-key.ts
+++ b/api/src/lib/api-key.ts
@@ -1,0 +1,40 @@
+import { createHash, randomBytes } from 'crypto';
+
+const CHARSET =
+	'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+/**
+ * Generate a new API key with cryptographically secure randomness.
+ * Format: ctd_<32 alphanumeric chars>
+ * Example: ctd_a8Kj2mNp4qRs6tUv8wXy0zB3dF5gH7jL
+ */
+export function generateApiKey(): string {
+	const bytes = randomBytes(32);
+	let key = 'ctd_';
+	for (let i = 0; i < 32; i++) {
+		key += CHARSET[bytes[i] % CHARSET.length];
+	}
+	return key;
+}
+
+/**
+ * Hash an API key using SHA-256 for secure storage.
+ */
+export function hashApiKey(key: string): string {
+	return createHash('sha256').update(key).digest('hex');
+}
+
+/**
+ * Get the prefix of an API key for identification.
+ * Returns the first 8 characters (e.g., "ctd_xxxx").
+ */
+export function getKeyPrefix(key: string): string {
+	return key.slice(0, 8);
+}
+
+/**
+ * Validate that a string matches the API key format.
+ */
+export function isValidApiKeyFormat(key: string): boolean {
+	return /^ctd_[a-zA-Z0-9]{32}$/.test(key);
+}

--- a/api/src/routes/api-keys.ts
+++ b/api/src/routes/api-keys.ts
@@ -1,0 +1,108 @@
+import { zValidator } from '@hono/zod-validator';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { ulid } from 'ulid';
+import { z } from 'zod';
+
+import { apiKey, db } from '@/db/index';
+import {
+	generateApiKey,
+	getKeyPrefix,
+	hashApiKey,
+} from '@/lib/api-key';
+
+const apiKeys = new Hono();
+
+// Request schemas
+const createApiKeySchema = z.object({
+	name: z.string().min(1).max(100).optional(),
+	expiresIn: z.number().int().positive().optional(), // milliseconds
+});
+
+// POST /api-keys - Generate new API key
+apiKeys.post(
+	'/',
+	zValidator('json', createApiKeySchema, (result, c) => {
+		if (!result.success) {
+			return c.json(
+				{ error: { code: 'VALIDATION_ERROR', issues: result.error.issues } },
+				400,
+			);
+		}
+		return undefined;
+	}),
+	async (c) => {
+		const body = c.req.valid('json');
+
+		const id = ulid();
+		const key = generateApiKey();
+		const keyHash = hashApiKey(key);
+		const keyPrefix = getKeyPrefix(key);
+		const now = new Date();
+
+		const expiresAt = body.expiresIn
+			? new Date(now.getTime() + body.expiresIn)
+			: null;
+
+		await db.insert(apiKey).values({
+			id,
+			name: body.name || 'default',
+			keyHash,
+			keyPrefix,
+			expiresAt,
+			createdAt: now,
+		});
+
+		return c.json(
+			{
+				key, // Only returned on creation
+				id,
+				name: body.name || 'default',
+				keyPrefix,
+				expiresAt: expiresAt?.getTime() ?? null,
+				createdAt: now.getTime(),
+			},
+			201,
+		);
+	},
+);
+
+// GET /api-keys - List keys (shows prefix only)
+apiKeys.get('/', async (c) => {
+	const keys = await db.query.apiKey.findMany({
+		orderBy: (k, { desc }) => [desc(k.createdAt)],
+	});
+
+	return c.json({
+		keys: keys.map((k) => ({
+			id: k.id,
+			name: k.name,
+			keyPrefix: k.keyPrefix,
+			lastUsedAt: k.lastUsedAt?.getTime() ?? null,
+			expiresAt: k.expiresAt?.getTime() ?? null,
+			createdAt: k.createdAt.getTime(),
+		})),
+	});
+});
+
+// DELETE /api-keys/:id - Revoke key
+apiKeys.delete('/:id', async (c) => {
+	const id = c.req.param('id');
+
+	const existing = await db.query.apiKey.findFirst({
+		where: (k, { eq }) => eq(k.id, id),
+	});
+
+	if (!existing) {
+		return c.json(
+			{ error: { code: 'NOT_FOUND', message: 'API key not found' } },
+			404,
+		);
+	}
+
+	await db.delete(apiKey).where(eq(apiKey.id, id));
+
+	return c.json({ success: true });
+});
+
+export { apiKeys };


### PR DESCRIPTION
## Summary
- Add `apiKey` table to database schema for storing API keys
- Create `api-key.ts` utilities for key generation, hashing, and validation
- Add `/api-keys` routes for CRUD operations:
  - `POST /api-keys` - Generate new API key (returns full key only on creation)
  - `GET /api-keys` - List keys (shows prefix only for security)
  - `DELETE /api-keys/:id` - Revoke key

Keys use cryptographically secure randomness (`crypto.randomBytes`) and are stored as SHA-256 hashes.

Format: `ctd_<32 alphanumeric chars>` (e.g., `ctd_a8Kj2mNp4qRs6tUv8wXy0zB3dF5gH7jL`)

Closes #45

## Test plan
- [x] TypeScript compiles without errors (for new code)
- [ ] Integration tests for key generation, listing, and deletion
- [ ] Verify key format matches SaaS implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)