### PR TITLE
feat: switch packaging to 7z and bump to v0.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Install 7-Zip
+        run: choco install 7zip -y
+
       - name: Parse nexus.toml config
         id: config
         shell: pwsh
@@ -176,16 +179,18 @@ jobs:
           https://github.com/ezmode-games/ctd
           "@ | Set-Content "$distDir/README.txt" -Encoding UTF8
 
-          # Create zip
-          $zipName = "ctd-$mod-v$version.zip"
-          Compress-Archive -Path "$distDir/*" -DestinationPath "dist/$zipName"
-          Write-Host "Created dist/$zipName"
+          # Create 7z archive
+          $archiveName = "ctd-$mod-v$version.7z"
+          Push-Location $distDir
+          & "C:\Program Files\7-Zip\7z.exe" a -t7z -mx=9 "../$archiveName" *
+          Pop-Location
+          Write-Host "Created dist/$archiveName"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-${{ needs.parse-tag.outputs.mod_name }}
-          path: dist/*.zip
+          path: dist/*.7z
 
   release:
     name: Create Release
@@ -240,6 +245,6 @@ jobs:
             cmake -B build
             cmake --build build --config Release
             ```' }}
-          files: artifacts/*.zip
+          files: artifacts/*.7z
           draft: ${{ needs.parse-tag.outputs.build_type == 'cmake' }}
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ctd-core"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "dirs",
  "hex",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "ctd-cyberpunk"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "crash-context",
  "crash-handler",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "ctd-fallout3"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ctd-core",
  "cxx",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "ctd-fallout4"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ctd-core",
  "cxx",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "ctd-newvegas"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ctd-core",
  "cxx",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "ctd-skyrim"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ctd-core",
  "cxx",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "ctd-ue5"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "crash-handler",
  "ctd-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.2"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/ezmode-games/ctd"

--- a/mods/fallout4/CMakeLists.txt
+++ b/mods/fallout4/CMakeLists.txt
@@ -157,6 +157,7 @@ target_link_libraries(${PLUGIN_TARGET} PRIVATE
     ws2_32
     kernel32
     bcrypt
+    RuntimeObject
 )
 
 # Ensure plugin waits for Rust build (which generates CXX headers)

--- a/mods/skyrim/CMakeLists.txt
+++ b/mods/skyrim/CMakeLists.txt
@@ -148,6 +148,7 @@ target_link_libraries(${PLUGIN_TARGET} PRIVATE
     ws2_32
     kernel32
     bcrypt
+    RuntimeObject
 )
 
 # Ensure plugin waits for Rust build (which generates CXX headers)

--- a/scripts/package-ue4ss-deps.ps1
+++ b/scripts/package-ue4ss-deps.ps1
@@ -53,10 +53,22 @@ if (Test-Path "$BuildDir/Game__Shipping__Win64/include") {
     date = (Get-Date -Format "yyyy-MM-dd")
 } | ConvertTo-Json | Set-Content "$OutPath/version.json"
 
-# Create zip
-$ZipPath = "$OutputDir/ue4ss-deps-$Version.zip"
-Write-Host "Creating $ZipPath..."
-Compress-Archive -Path $OutPath -DestinationPath $ZipPath -Force
+# Create 7z archive
+$ArchivePath = "$OutputDir/ue4ss-deps-$Version.7z"
+Write-Host "Creating $ArchivePath..."
 
-Write-Host "Done! Upload $ZipPath to GitHub Releases"
-Write-Host "Size: $([math]::Round((Get-Item $ZipPath).Length / 1MB, 2)) MB"
+# Find 7z executable
+$7zPath = "C:\Program Files\7-Zip\7z.exe"
+if (-not (Test-Path $7zPath)) {
+    $7zPath = "C:\Program Files (x86)\7-Zip\7z.exe"
+}
+if (-not (Test-Path $7zPath)) {
+    $7zPath = "7z"  # Try PATH
+}
+
+Push-Location $OutPath
+& $7zPath a -t7z -mx=9 "../ue4ss-deps-$Version.7z" * | Out-Null
+Pop-Location
+
+Write-Host "Done! Upload $ArchivePath to GitHub Releases"
+Write-Host "Size: $([math]::Round((Get-Item $ArchivePath).Length / 1MB, 2)) MB"

--- a/scripts/release-mod.ps1
+++ b/scripts/release-mod.ps1
@@ -15,8 +15,8 @@ param(
 $ErrorActionPreference = "Stop"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $Tag = "$Mod-v$Version"
-$ZipName = "ctd-$Mod-v$Version.zip"
-$ZipPath = "dist/$ZipName"
+$ArchiveName = "ctd-$Mod-v$Version.7z"
+$ArchivePath = "dist/$ArchiveName"
 
 Write-Host "=== Releasing $Mod v$Version ===" -ForegroundColor Cyan
 
@@ -49,8 +49,8 @@ Write-Host "`n[2/5] Packaging..." -ForegroundColor Yellow
 & "$ScriptDir/package-mod.ps1" -Mod $Mod -Version $Version
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
-if (-not (Test-Path $ZipPath)) {
-    Write-Error "Package not found at $ZipPath"
+if (-not (Test-Path $ArchivePath)) {
+    Write-Error "Package not found at $ArchivePath"
     exit 1
 }
 
@@ -98,8 +98,8 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Step 5: Upload artifact
-Write-Host "`n[5/5] Uploading $ZipName..." -ForegroundColor Yellow
-gh release upload $Tag $ZipPath --clobber
+Write-Host "`n[5/5] Uploading $ArchiveName..." -ForegroundColor Yellow
+gh release upload $Tag $ArchivePath --clobber
 
 # Publish if it was a draft
 if ($HasCMake) {

--- a/status.json
+++ b/status.json
@@ -1,68 +1,18 @@
 {
   "$schema": "https://ezmode.games/schemas/ctd-status.json",
-  "generated_at": "2026-01-09T03:35:08Z",
+  "generated_at": "2026-01-14T02:37:57Z",
   "repository": "https://github.com/ezmode-games/ctd",
   "mods": {
-    "fallout3": {
-      "name": "CTD Crash Reporter",
-      "game": "Fallout 3",
-      "status": "scaffolding",
-      "version": null,
-      "build_type": "unknown",
-      "quality": "scaffolding",
-      "features": [],
-      "published": {
-        "github": null,
-        "nexus": null,
-        "ezmode": null
-      }
-    },
-    "skyrim": {
-      "name": "CTD Crash Reporter",
-      "game": "The Elder Scrolls V: Skyrim",
-      "status": "beta",
-      "version": "0.1.0",
-      "build_type": "cmake",
-      "quality": "good",
-      "features": [
-        "crash_capture",
-        "load_order",
-        "mod_fingerprinting"
-      ],
-      "published": {
-        "github": "https://github.com/ezmode-games/ctd/releases/tag/skyrim-v0.1.0",
-        "nexus": null,
-        "ezmode": null
-      }
-    },
     "newvegas": {
       "name": "CTD Crash Reporter",
       "game": "Fallout: New Vegas",
       "status": "scaffolding",
-      "version": null,
-      "build_type": "unknown",
+      "version": "0.1.2",
+      "build_type": "cmake",
       "quality": "scaffolding",
       "features": [],
       "published": {
         "github": null,
-        "nexus": null,
-        "ezmode": null
-      }
-    },
-    "fallout4": {
-      "name": "CTD Crash Reporter",
-      "game": "Fallout 4",
-      "status": "beta",
-      "version": "0.1.0",
-      "build_type": "cmake",
-      "quality": "good",
-      "features": [
-        "crash_capture",
-        "load_order",
-        "mod_fingerprinting"
-      ],
-      "published": {
-        "github": "https://github.com/ezmode-games/ctd/releases/tag/fallout4-v0.1.0",
         "nexus": null,
         "ezmode": null
       }
@@ -71,7 +21,7 @@
       "name": "CTD Crash Reporter",
       "game": "Unreal Engine 5 (Generic)",
       "status": "alpha",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "build_type": "cargo",
       "quality": "experimental",
       "features": [
@@ -79,7 +29,40 @@
         "pak_scanning"
       ],
       "published": {
-        "github": "https://github.com/ezmode-games/ctd/releases/tag/ue5-v0.1.0",
+        "github": "https://github.com/ezmode-games/ctd/releases/tag/ue5-v0.1.2",
+        "nexus": null,
+        "ezmode": null
+      }
+    },
+    "elden-ring": {
+      "name": "CTD Crash Reporter",
+      "game": "Elden Ring",
+      "status": "wip",
+      "version": null,
+      "build_type": "cmake",
+      "quality": "scaffolding",
+      "features": [
+        "crash_capture"
+      ],
+      "published": {
+        "github": null,
+        "nexus": null,
+        "ezmode": null
+      }
+    },
+    "cyberpunk": {
+      "name": "CTD Crash Reporter",
+      "game": "Cyberpunk 2077",
+      "status": "beta",
+      "version": "0.1.2",
+      "build_type": "cargo",
+      "quality": "good",
+      "features": [
+        "crash_capture",
+        "mod_scanning"
+      ],
+      "published": {
+        "github": "https://github.com/ezmode-games/ctd/releases/tag/cyberpunk-v0.1.2",
         "nexus": null,
         "ezmode": null
       }
@@ -101,19 +84,52 @@
         "ezmode": null
       }
     },
-    "cyberpunk": {
+    "fallout4": {
       "name": "CTD Crash Reporter",
-      "game": "Cyberpunk 2077",
+      "game": "Fallout 4",
       "status": "beta",
-      "version": "0.1.0",
-      "build_type": "cargo",
+      "version": "0.1.2",
+      "build_type": "cmake",
       "quality": "good",
       "features": [
         "crash_capture",
-        "mod_scanning"
+        "load_order",
+        "mod_fingerprinting"
       ],
       "published": {
-        "github": "https://github.com/ezmode-games/ctd/releases/tag/cyberpunk-v0.1.0",
+        "github": "https://github.com/ezmode-games/ctd/releases/tag/fallout4-v0.1.2",
+        "nexus": null,
+        "ezmode": null
+      }
+    },
+    "fallout3": {
+      "name": "CTD Crash Reporter",
+      "game": "Fallout 3",
+      "status": "scaffolding",
+      "version": "0.1.2",
+      "build_type": "cmake",
+      "quality": "scaffolding",
+      "features": [],
+      "published": {
+        "github": null,
+        "nexus": null,
+        "ezmode": null
+      }
+    },
+    "skyrim": {
+      "name": "CTD Crash Reporter",
+      "game": "The Elder Scrolls V: Skyrim",
+      "status": "beta",
+      "version": "0.1.2",
+      "build_type": "cmake",
+      "quality": "good",
+      "features": [
+        "crash_capture",
+        "load_order",
+        "mod_fingerprinting"
+      ],
+      "published": {
+        "github": "https://github.com/ezmode-games/ctd/releases/tag/skyrim-v0.1.2",
         "nexus": null,
         "ezmode": null
       }


### PR DESCRIPTION
## Summary
- Switch all packaging from zip to 7z (better compression, preferred by Nexus)
- Fix CMake linker error by adding RuntimeObject.lib
- Bump version to 0.1.2 for skyrim, fallout4, cyberpunk
- Regenerate status.json

## Changes
- `scripts/package-mod.ps1` - Use 7z, support Cargo build paths
- `scripts/package-ue4ss-deps.ps1` - Use 7z
- `scripts/release-mod.ps1` - Use .7z extension
- `.github/workflows/release.yml` - Install 7z, output .7z
- `mods/skyrim/CMakeLists.txt` - Add RuntimeObject lib
- `mods/fallout4/CMakeLists.txt` - Add RuntimeObject lib

## Test plan
- [x] Built skyrim, fallout4, cyberpunk locally
- [x] Packaged all as .7z (~1.2-1.3MB each)
- [ ] CI workflow will validate on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)