### PR TITLE
feat: add automated version bump workflow

### DIFF
--- a/scripts/generate-status.ps1
+++ b/scripts/generate-status.ps1
@@ -189,9 +189,9 @@ $output = [ordered]@{
     mods = $mods
 }
 
-# Write JSON
+# Write JSON without BOM (UTF8 with BOM can break some JSON parsers)
 $json = $output | ConvertTo-Json -Depth 10
-$json | Set-Content $OutputFile -Encoding UTF8
+[System.IO.File]::WriteAllText($OutputFile, $json, [System.Text.UTF8Encoding]::new($false))
 
 Write-Host "Generated: $OutputFile" -ForegroundColor Green
 Write-Host $json

--- a/status.json
+++ b/status.json
@@ -1,6 +1,6 @@
-﻿{
+{
     "$schema":  "https://ezmode.games/schemas/ctd-status.json",
-    "generated_at":  "2026-01-14T04:06:19Z",
+    "generated_at":  "2026-01-14T04:40:38Z",
     "repository":  "https://github.com/ezmode-games/ctd",
     "mods":  {
                  "fallout3":  {


### PR DESCRIPTION
## Summary
- Add `scripts/bump-version.ps1` to automate version bumping across the workspace
- Update Fallout 3 and New Vegas status from `scaffolding` to `beta`

## Version Bump Script
Usage: `.\scripts\bump-version.ps1 -Version 0.1.3`

The script automates the release workflow:
1. Updates version in `Cargo.toml` workspace
2. Runs `cargo update --workspace` to update `Cargo.lock`
3. Regenerates `status.json`
4. Commits changes with message `chore: bump version to X.Y.Z`
5. Creates tags for all releasable mods (skyrim, fallout4, fallout3, newvegas, cyberpunk)
6. Pushes to origin (tags trigger CI draft releases)

Supports `-DryRun` flag to preview changes without making them.

## FO3/NV Status Update
Both Fallout 3 and New Vegas now build and work correctly. Updated their status from scaffolding to beta with full features:
- crash_capture
- load_order
- mod_fingerprinting

## Test plan
- [x] Tested `bump-version.ps1 -Version 0.1.3 -DryRun` - works correctly
- [x] Generated `status.json` reflects FO3/NV as beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)