### PR TITLE
feat(elden-ring): Elden Ring v0.1.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Automatic crash reporting for modded games. Captures crash context and helps ide
 | Game | Plugin | Status | Version | Download |
 |------|--------|--------|---------|----------|
 | Cyberpunk 2077 | RED4ext | Beta | v0.1.4 | [v0.1.4](https://github.com/ezmode-games/ctd/releases/tag/cyberpunk-v0.1.4) |
+| Elden Ring | UE4SS | Alpha | v0.1.4 | [v0.1.4](https://github.com/ezmode-games/ctd/releases/tag/elden-ring-v0.1.4) |
 | Fallout 3 | FOSE | Beta | v0.1.4 | [v0.1.4](https://github.com/ezmode-games/ctd/releases/tag/fallout3-v0.1.4) |
 | Fallout 4 | F4SE | Beta | v0.1.4 | [v0.1.4](https://github.com/ezmode-games/ctd/releases/tag/fallout4-v0.1.4) |
 | Fallout: New Vegas | NVSE | Beta | v0.1.4 | [v0.1.4](https://github.com/ezmode-games/ctd/releases/tag/newvegas-v0.1.4) |
 | Oblivion Remastered | UE4SS | Alpha | v0.1.4 | [v0.1.4](https://github.com/ezmode-games/ctd/releases/tag/oblivion-remastered-v0.1.4) |
 | The Elder Scrolls V: Skyrim | SKSE64 | Beta | v0.1.4 | [v0.1.4](https://github.com/ezmode-games/ctd/releases/tag/skyrim-v0.1.4) |
-| Elden Ring | UE4SS | Wip | - | - |
 
 ## What It Captures
 

--- a/mods/elden-ring/nexus.toml
+++ b/mods/elden-ring/nexus.toml
@@ -1,14 +1,19 @@
 # Nexus Mods metadata for CTD Crash Reporter - Elden Ring
 
+[nexus]
+game_slug = "eldenring"
+# mod_id = 12345  # uncomment when published
+
 [mod]
 name = "CTD Crash Reporter"
-version = "0.1.0"
+version = "0.1.4"
 game = "elden-ring"
 game_id = 2922  # Elden Ring on Nexus
 
 [build]
 type = "ue4ss"
 arch = "x64"
+plugin_path = "Mods/CTDCrashReporter/dlls"
 
 [description]
 summary = "Automatic crash reporting for Elden Ring"

--- a/status.json
+++ b/status.json
@@ -127,17 +127,17 @@
                                                  }
                                },
                  "elden-ring":  {
-                                    "name":  "CTD Crash Reporter",
-                                    "game":  "Elden Ring",
-                                    "status":  "wip",
-                                    "version":  null,
+                                   "name":  "CTD Crash Reporter",
+                                   "game":  "Elden Ring",
+                                   "status":  "alpha",
+                                   "version":  "0.1.4",
                                     "build_type":  "cmake",
-                                    "quality":  "scaffolding",
+                                    "quality":  "experimental",
                                     "features":  [
                                                      "crash_capture"
                                                  ],
                                     "published":  {
-                                                      "github":  null,
+                                                      "github":  "https://github.com/ezmode-games/ctd/releases/tag/elden-ring-v0.1.4",
                                                       "nexus":  null,
                                                       "ezmode":  null
                                                   }


### PR DESCRIPTION
## Summary
- Initialize RE-UE4SS submodule for Elden Ring mod build support
- Update nexus.toml with version 0.1.4 and correct UE4SS plugin path
- Update status from "wip" to "alpha" with release URL

## Test plan
- [x] Build completed successfully with VS2022
- [x] Package created: `dist/ctd-elden-ring-v0.1.4.7z` (1253 KB)
- [ ] Manual test on Elden Ring (optional before release)

## Notes
The patternsleuth submodule has an upstream lint error (`unused import: bail_out`) that requires a local patch to build. This is the same issue as Oblivion Remastered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)